### PR TITLE
FAQ Update May 18th, 2022

### DIFF
--- a/src/assets/i18n/faq/en-US.yml
+++ b/src/assets/i18n/faq/en-US.yml
@@ -87,9 +87,9 @@
   color: "#e07a37"
   questions:
     - q: What happens if all of my pieces are removed from the map?
-      a: Unfortunately, you're out of the game. Thankfully, the game should be over at any moment if this happens.
+      a: Unfortunately, you’re probably out of the game. However, if the Riverfolk Company or hirelings are in play, you can build a building again if you rule a clearing. Either way, if this happens, the game will likely end at a moment’s notice!
       laws:
-        - "6."
+        - "6"
 
     - q: Can someone move a piece into the clearing with my keep?
       a: Yes! "Place" is a different keyword from "move."
@@ -97,10 +97,16 @@
         - "4.2"
         - "6.2.2"
 
-    - q: How do the Marquise build using their supply chain?
-      a: They must control the clearing the wood is in, the clearing they want to build in, and each clearing on the route from the wood to the destination.
+    - q: If someone ambushes me in a battle at the Keep, when do my warriors get placed back in the Keep’s clearing?
+      a: Immediately, as long as you spend a card. This means you can avoid the check for “no remaining warriors” prompted by the ambush. 
       laws:
-        - "6.5.4.2"
+        - "4.3.1"
+        - "6.2.3"
+
+    - q: Can the Marquise place hirelings at the Keep?
+      a: Yes! 
+      laws:
+        - "6.2.3"
 
 - category: Eyrie Dynasties
   color: "#416eb0"
@@ -125,6 +131,12 @@
       laws:
         - "7.8.4"
 
+    - q: If I have the Charismatic leader and Recruit, but I have one warrior left in my supply. Do I place no warriors or one warrior before going into Turmoil?
+      a: Place one. If you are prompted to place pieces but cannot place them all, you must place as many as possible.
+      laws:
+        - "7.7"
+        - "7.8.3"
+
 - category: Woodland Alliance
   color: "#68b653"
   questions:
@@ -138,6 +150,20 @@
       laws:
         - "6.2.2"
         - "8.4.1"
+
+    - q: What happens if a hireling removes sympathy?
+      a: The player controlling the hireling would trigger Outrage, since Outrage specifies “When a player removes…” This is also covered explicitly in Law E.3.7.
+      laws:
+        - "8.2.6"
+        - "16.4.3.7"
+
+    - q: Does the Vagabond cause Outrage?
+      a: Nope. The Vagabond is a pawn, not a warrior.
+      laws:
+        - "8.2.6"
+
+    - q: Do hirelings cause Martial Law?
+      a: Hirelings controlled by an enemy player will add to that player’s faction warriors. So if the Eyrie had 1 Eyrie warrior and 2 hireling warriors they controlled in a clearing, that clearing would prompt Martial Law. However, uncontrolled hireling warriors would not prompt Martial Law.
 
 - category: Vagabond
   color: "#6d6e70"
@@ -154,11 +180,54 @@
         - "9.2.2"
 
     - q: If I move Allied warriors of the Woodland Alliance into a sympathetic clearing, do I trigger Outrage?
-      a: Yes! What's that wily guy doing leading Woodland warriors?
+      a: Nope! (*This ruling was changed as of the release of the Marauder Expansion and the 8th Printing, because the Vagabond’s Allied movement now uses the “Force” keyword.)
       laws:
         - "8.2.6"
         - "9.2.9"
-   
+
+    - q: Does the Vagabond go Hostile with a faction when he removes one of their buildings or tokens, but no warriors? 
+      a: Nope! There are no witnesses to see him. Burn it all down!
+      laws:
+        - "9.2.9.3"
+
+    - q: If the Vagabond removes a hireling warrior controlled by another faction, does the Vagabond become Hostile with that faction? 
+      a: Nope! The hirelings are not faction pieces of that faction.
+      laws:
+        - "9.2.9.3"
+
+    - q: If the Vagabond battles using a controlled hireling and removes enemy pieces, does the Vagabond turn Hostile with that faction or gain Infamy points if they’re already Hostile? 
+      a: Nope! Hirelings don’t use the abilities of their controlling faction (E.3.5) or let their controlling faction score points for removing enemy pieces (E.3.6).
+      laws:
+        - "9.2.9.3"
+        - "16.4.3.5"
+        - "16.4.3.6"
+
+    - q: Can the Vagabond move Allied warriors using the Ferry from the Underworld Expansion? If so, does the Ally faction also draw a card? 
+      a: Yes to both!
+      laws:
+        - "16.2.2.5"
+
+    - q: Can a Vagabond form a coalition with a player who has activated a dominance card? Can a player activate a dominance card after a Vagabond formed a coalition with them? 
+      a: A Vagabond cannot form a coalition with a dominance player, since they have no victory point marker on the track. However, a player can activate a dominance card after a Vagabond forms a coalition with them!
+      laws:
+        - "9.2.8"
+
+    - q: The Vagabond is in a coalition with me. Can I still battle him? Can he still battle me? 
+      a: No, neither of you can battle each other. (*This ruling changed as of the Marauder Expansion and the 8th Printing. The Battle rules now specify that you must battle an enemy, which means any player not in a coalition.)
+      laws:
+        - "4.3"
+        - "9.2.8"
+
+    - q: Can I gain Infamy victory points by removing a piece with Strike? 
+      a: Nope! Infamy specifies that you must remove the piece in battle on your turn. Killing someone with a crossbow is the coward’s way, after all.
+      laws:
+        - "9.2.9.3.1"
+
+    - q: Can the Vagabond move Allied warriors using the Ferry from the Underworld Expansion? If so, does the Ally faction also draw a card? 
+      a: Yes to both!
+      laws:
+        - "16.2.2.5"
+
 - category: Riverfolk Company
   color: "#5bc3bd"
   questions:

--- a/src/assets/i18n/faq/en-US.yml
+++ b/src/assets/i18n/faq/en-US.yml
@@ -241,6 +241,24 @@
       laws:
         - "11.5.3"
 
+    - q: Can the Riverfolk refuse to sell you one of their services?
+      a: Nope! As long as you pay the cost, you get the service.
+      laws:
+        - "11.2.6"
+
+    - q: Can Riverfolk Mercenaries be used to battle hirelings controlled by the Riverfolk?
+      a: Yes! Mercenaries just won’t battle against the Riverfolk themselves, not controlled hirelings.
+      laws:
+        - "11.2.7"
+
+- category: Lizard Cult
+  color: "#fcf065"
+  questions:
+    - q: Can I use Convert or Sanctify to only remove a warrior or building, but not place my own warrior or building there?
+      a: Nope! The rule says that “you must complete the conspiracy,” and faction rules overrule general rules if you cannot fulfill them both. 
+      laws:
+        - "10.4.3"
+
 - category: Keepers in Iron
   color: "#8b8d90"
   questions:
@@ -253,6 +271,11 @@
       a: You do not need to rule in order to battle—only to delve!
       laws:
         - "15.5.2.2"
+
+    - q: If hirelings remove a relic, how do I resolve the Prized Trophy ability?
+      a: No victory points are awarded. If the hireling is controlled, the controlling player decides where to put the relic. If the hireling is uncontrolled, the player taking their turn decides where to put the relic.
+      laws:
+        - "15.2.5"
         
     - q: Does the Keepers’ Prized Trophies ability trigger if the Vagrant Vagabond removes a relic by using Instigate, but they’re in a coalition with the Keepers?
       a: As written, no, since the Vagrant is not an enemy in this case. Why the Vagrant would want to do this is beyond me, though!
@@ -266,6 +289,7 @@
       a: The Hundreds player does, matching the fact that the player taking hits chooses the order of removing buildings and tokens. So if you took two hits and you have the warlord, two warriors, and a stronghold, you could remove two warriors or you could remove one warrior and the warlord. Though we wouldn’t recommend removing the warlord early!
       laws:
         - "14.2.2"
+        - "4.3.4"
         
     - q: What exactly is required for the Hundreds to oppress a clearing?
       a: You need to (1) rule, (2) have a Hundreds piece there, and (3) have no enemy pieces there. For example, you do oppress with a mob and a Riverfolk Mercenary warrior. You do not oppress with only a Riverfolk Mercenary warrior. You do not oppress with a mob, a Riverfolk Mercenary warrior, and a Riverfolk trade post. 
@@ -276,6 +300,11 @@
       a: No. Rowdy makes you draw more cards only during your draw step in Evening.
       laws:
         - "14.7.6"
+
+    - q: Do I declare whether I’m using my Looters before or after the defender declares that they are ambushing?
+      a: Declaring Looters.
+      laws:
+        - "14.2.5"
 
 - category: Advanced Setup
   color: "#000"

--- a/src/assets/i18n/faq/en-US.yml
+++ b/src/assets/i18n/faq/en-US.yml
@@ -23,14 +23,17 @@
   color: "#000000"
   questions:
     - q: Which pieces are buildings? Which are tokens?
-      a: Broadly, square cardboard pieces that go in slots are buildings, while circular cardboard pieces are tokens. You’ll find detailed lists of buildings and tokens on the back of the learn-to-play and the backs of the faction boards.
+      a: Buildings are square cardboard pieces that go in open building slots on the map, while tokens are circular cardboard pieces that do not occupy a slot. You’ll find detailed lists of buildings and tokens on the back of the learn-to-play and the backs of the faction boards.
       laws: 
         - "2.5"
+        - "16.6.3"
+        - "16.6.32"
     
     - q: Do I lose points if one of my buildings is removed?
       a: Nope!
       laws: 
         - "2.5.2"
+        - "16.6.22"
 
     - q: Can I play multiple ambush cards in a battle?
       a: Nope! Just one.
@@ -38,21 +41,17 @@
         - "4.3.1"
 
     - q: Do the Favor... cards really remove all enemy pieces from those clearings?
-      a: Yes. Every single one—except the Vagabond, of course. What a sneaky guy. However, Ruins and the items beneath them are not removed! Lucky Vagabond.
+      a: Yes, except for the Vagabond and the Lord of the Hundreds’ warlord.
       laws: 
-        - "2.1"
+        - "9.2.2"
+        - "14.2.2"
 
     - q: How do I get rid of enemy tokens, like sympathy tokens?
-      a: You battle them, like any other piece. You can also remove them with Favor cards. 
+      a: Just like any other other piece, they can be battled and can be removed by powers that say they remove pieces. 
       laws:
         - "2.1"
         - "2.5"
         - "4.3"
-
-    - q: Do the Favor... cards score victory points?
-      a: Yes. Every token and building removed scores one point.
-      laws: 
-        - "3.2.1"
     
     - q: Does placing a piece in a sympathetic clearing trigger Outrage?
       a: Nope! You have to move in warriors or remove the sympathy to trigger it.
@@ -64,16 +63,25 @@
       a: Most often, back to the board or supply of the owning player. This is described more in 2.5.
       laws:
         - "2.5"
+        - "16.6.22"
 
     - q: What does "activating" a piece for crafting mean? Do I do anything with it?
-      a: Nope. Activating just means "I have it, and I want to use it for crafting." You don't need to get rid of it or do anything other than point at it and say, "I'm activating this to craft a card."
+      a: Nope. Activating just means “I have it, and I want to use it for crafting.” You don’t need to get rid of it or do anything other than point at it and say, “I’m activating this to craft a card.”
       laws:
         - "4.1.1"
 
-    - q: Are Ruins placed even if there is no Vagabond in the game?
-      a: Yes. Ruins are always placed on the board.
+    - q: Can I not consent to the action of another player?
+      a: Nope, there are no actions in Root that require consent. For example, the Vagabond does not require consent to form a coalition with someone or Aid someone, and a player does not need the Riverfolk’s consent to buy services from them.
       laws:
-        - "2.2.4"
+        - "9.2.8"
+        - "9.5.4"
+        - "11.2.6"
+
+- category: Cards
+  color: "#000000"
+  questions:
+    - q: The Armorers card says “rolled hits”. Does it really mean “rolled hits” specifically and not “hits”?
+      a: Yes indeed! “Rolled hits” means only the hits rolled.
 
 - category: Marquise de Cat
   color: "#e07a37"

--- a/src/assets/i18n/faq/en-US.yml
+++ b/src/assets/i18n/faq/en-US.yml
@@ -312,8 +312,29 @@
     - q: "Keepers in Iron: For the second step of placing relics, do I get to choose which relics go in which clearings?"
       a: Place them randomly. (That said, it usually won’t make much difference, since people can adjust their strategy to prevent you from delving efficiently.)
       
-    - q: "Keepers in Iron: What happens if there aren’t any two adjacent clearings on the map edge?
-      a: Return the Keepers’ advanced setup card to the box and draw new advanced setup cards until you draw a militant faction (red with swords). This faction replaces the Keepers. We will likely add general mulligan rules that mirror this as more factions get added to the game and it becomes increasingly possible to draw a faction that is impossible to set up."
+    - q: "Keepers in Iron: What happens if there aren’t any two adjacent clearings on the map edge?"
+      a: Return the Keepers’ advanced setup card to the box and draw new advanced setup cards until you draw a militant faction (red with swords). This faction replaces the Keepers. We will likely add general mulligan rules that mirror this as more factions get added to the game and it becomes increasingly possible to draw a faction that is impossible to set up.
+
+- category: Hirelings
+  color: "#000"
+  questions:
+    - q: "The Exile: Can I give the Exile an exhausted item?"
+      a: Yes!
+
+    - q: "The Exile: Can I give the Exile multiple items on the same turn?"
+      a: Yes!
+
+    - q: "Highway Bandits: If the Highway Bandits remove a Marquise warrior, can the Marquise use Field Hospitals?"
+      a: Nope. The power happens while moving “on a path” with Highway Bandits, so they are not in a clearing at that moment.
+
+    - q: "Spring Uprising: Can a hireling battle the Spring Uprising?"
+      a: Nope. They do not have a hand of cards to discard from.
+
+    - q: "Warm Sun Prophets: When I force a battle and the defender plays an ambush card, which placer makes decisions about piece removal and playing counter-ambushes?"
+      a: The player who is being forced to battle.
+
+    - q: "Flame Bearers: Does “warriors first” preclude me from removing undefended buildings or tokens of a player if there are warriors of another player there?"
+      a: No, this works in the same way as battle or the Vagabond’s Strike—if a player has warriors there, you must remove the warriors first.
 
 - category: Landmarks
   color: "#000"
@@ -324,3 +345,5 @@
     - q: "Lost City: Can I revolt in the Lost City if I have already filled the clearing’s slots with my bases, but I still have a base left on my board?"
       a: Yes, you can! The Lost City is very vulnerable to revolts, since it can be treated as any suit.
 
+    - q: "Ferry: If I move the Ferry to a clearing with a sympathy token, do I draw the card first or trigger Outrage first?"
+      a: These happen at the same time, so you decide the order.


### PR DESCRIPTION
Since all of the rules in https://root.seiyria.com/ has been updated to 8th print version listed in [Root Clarifications and Errata](https://docs.google.com/document/d/1yBwLDRo0OuziCeRiX2SOpv63gH8_dmoCrGd8NyDuyC8/edit), it make more sense to also update FAQ to match [Root FAQ](https://docs.google.com/document/d/1usz2D3BCurx2nKEOtDseCwNaFL7vOArvGHdrIt_KPio/edit#) to avoid confusion.

Especially for the following rule tweaks that has the opposite answers comparing to the previous prints.

- If I move Allied warriors of the Woodland Alliance into a sympathetic clearing, do I trigger Outrage?
Nope! (*This ruling was changed as of the release of the Marauder Expansion and the 8th Printing, because the Vagabond’s Allied movement now uses the “Force” keyword.)
- The Vagabond is in a coalition with me. Can I still battle him? Can he still battle me?
No, neither of you can battle each other. (*This ruling changed as of the Marauder Expansion and the 8th Printing. The Battle rules now specify that you must battle an enemy, which means any player not in a coalition.)

All commits using date `May 18th, 2022` to match the latest `Change Log`, even the [doc](https://docs.google.com/document/d/1usz2D3BCurx2nKEOtDseCwNaFL7vOArvGHdrIt_KPio/edit#) title still has `May 5th, 2022`
