### PR TITLE
Correct Trap/Snare effect description

### DIFF
--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -944,7 +944,7 @@
         - name: Bomba.
           text: Al voltear y revelar una ficha de Bomba, retira todas las piezas enemigas del claro, y después retira la ficha de Bomba.
         - name: Trampa.
-          text: Mientras una ficha de Trampa esté bocarriba, los enemigos no pueden colocar ni mover piezas desde o hacia este claro.
+          text: Mientras una ficha de Trampa esté bocarriba, los enemigos no pueden colocar piezas en este claro, ni mover piezas desde este claro.
         - name: Extorsión.
           text: Al voltear una ficha de Extorsión, quita una carta al azar de la mano de cada jugador que tenga al menos una pieza en dicho claro. Por cada ficha de Extorsión que haya bocarriba, robarás una carta extra en tu Noche.
         - name: Asalto.


### PR DESCRIPTION
@humbertoish pointed out in Woodland Warriors Discord that the Spanish translation of the Snare ("Trap") is incorrect because it states pieces may not be moved into the snared clearing. They gave this translation instead (which I have edited to use "este" rather than "ese" to match the other rules more closely). I am not a fluent Spanish speaker but from what small amount I know and from double-checking with Google Translate this translation appears to correct the error and bring the meaning in line with the English rules about Snare.