### PR TITLE
Update Spanish Rules

### DIFF
--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -168,25 +168,29 @@
         - name: "Paso 4: Recibir Golpes."
           text: "Cada golpe que da un bando retira una pieza del otro bando en el claro de batalla _(obtienes un punto de victoria por cada edificio o ficha enemiga que retires)_. El bando que recibe un golpe decide en qué orden se retiran sus piezas, aunque todos sus guerreros han de ser retirados antes de que sus edificios o fichas puedan retirarse; también escogen el orden de cualquier efecto que provoque la retirada de sus piezas."
 
-- name: Preparación
+- name: Preparación de la Partida
   color: "#000000"
+  pretext: Si algún jugador es novato, usa la Preparación Estándar (`rule:5.1`). Si todos habéis jugado y queréis más variedad, usad la Preparación Avanzada (`rule:16.1`). Si queréis jugar con cinco o más facciones que comienzan en claros de esquinas, tenéis que usar la Preparación Avanzada.
   children:
-    - name: Preparación estándar
+    - name: Preparación Estándar
       children:
-        - name: "Paso 1: Asignar facciones y jugador inicial"
-          text: Asigna una facción a cada jugador empleando el método que prefieras. Las combinaciones de facciones viables según el número de jugadores se describen en el el apartado "Combinaciones de facciones" (Apéndice A del Reglamento; en esta web puedes utilizar la herramienta de la calculadora). Determina el jugador inicial al azar y el orden de turno según cómo estéis sentados. Cada jugador coge el tablero y las piezas de su facción según indica el reverso del tablero de tu facción.
-        - name: "Paso 2: Colocar marcadores de puntuación."
-          text: Cada jugador coloca su contador de puntuación sobre el "0" del contador del tablero.
-        - name: "Paso 3: Mano inicial."
-          text: Si solo vais a jugar dos jugadores, retirad las 4 cartas de Dominancia del mazo. Baraja el mazo; después, cada jugador roba tres cartas _(alternativamente, robad 5 y elegid solo 3; esto es más recomendable si ya tenéis experiencia en el juego)_.
-        - name: "Paso 4: Ruinas."
-          text: Coloca las Ruinas sobre cada espacio del tablero marcado con una "R" _(cuatro en total)_.
-        - name: "Paso 5: Preparar la reserva de objetos."
-          text: "Coloca los siguientes objetos en las casillas correspondientes de la reserva de objetos de la parte superior del tablero: 2 `item:boot`, 2 `item:sack`, 1 `item:crossbow`, 1 `item:hammer`, 2 `item:sword`, 2 `item:tea`, 2 `item:coin`."
-        - name: "Paso 6: Preparar el resto de elementos."
-          text: Reparte las cartas de resumen de las facciones a petición, y coloca los 2 dados de batalla junto al mapa.
-        - name: "Paso 7: Preparación individual."
-          text: Por orden de preparación (A, B, C, etc.) cada jugador sigue los pasos de preparación de su tablero de facción, descritos tanto en las reglas como en el reverso de su tablero de facción. _(El orden se verá alterado si jugáis con reglas de preparación avanzada.)_
+        - name: "Paso 1: Asignar Facciones y Jugador Inicial"
+          text: Asigna una facción a cada jugador usando cualquier método. Determina al azar el orden de asiento y el jugador inicial, el orden de turno va hacia su izquierda. Cada jugador toma su tablero de facción y todas sus piezas, tal y como se describe en la parte trasera del mismo.
+        - name: "Paso 2: Colocar Marcadores de Puntuación."
+          text: Cada jugador coloca su contador de puntuación en la casilla "0" del contador.
+        - name: "Paso 3: Robar Mano Iniciales."
+          text: Si estáis jugando dos jugadores, quita las cuatro cartas de dominancia del mazo. Baraja el mazo. Cada jugador roba tres cartas.
+        - name: "Paso 4: Colocar Ruinas."
+          text: Coloca una ficha de ruina en cada espacio del mapa marcado con una "R" _(cuatro en total)_.
+        - name: "Paso 5: Formar la Reserva común de Objetos."
+          text: "Coloca estos objetos en los espacios correspondientes de la reserva de objetos en la parte superior del mapa: 2 `item:boot`, 2 `item:sack`, 1 `item:crossbow`, 1 `item:hammer`, 2 `item:sword`, 2 `item:tea`, 2 `item:coin`."
+        - name: "Paso 6: Otras Piezas."
+          text: Reparte las cartas de resumen de facción según se necesiten, después coloca los dos dados junto al mapa.
+        - name: "Paso 7: Preparar Facciones."
+          text: En orden de preparación (A, B, C, etc.) cada jugador sigue las instrucciones de preparación de la sección de reglas que está en la parte trasera de su tablero.
+
+    - name: Alcance
+      pretext: Para preparar un juego compensado, escoge facciones cuyos valores sumados de **alcance** sean al menos el valor total de alcance recomendado para el número de jugadores. _(Los jugadores más osados pueden usar cualquier combinación de facciones con un Alcance de 17+)_. Para ver el Alcance recomendado para tu cantidad de jugadores, haz clic en el ícono de Calculadora en la esquina superior derecha de la app.
 
 - name: El Marquesado
   color: "#e07a37"

--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -30,7 +30,8 @@
     - name: Secuencia de Juego
       children:
         - name: Turno.
-          text: Cada turno de un jugador consta de tres fases: Alba, Día y Noche. Cualquier texto que diga "al principio de" una fase, sucede antes de cualquier otra cosa en esa fase, si el texto dice "al final de" sucede después de todo lo demás en esa fase y justo antes del inicio de la siguiente, si la hay. Después de que un jugador finalice su Noche, el siguiente jugador en sentido horario comienza su turno. El juego continúa hasta que un jugador gana la partida (`rule:3.1`).
+          text: > 
+            Cada turno de un jugador consta de tres fases: Alba, Día y Noche. Cualquier texto que diga "al principio de" una fase, sucede antes de cualquier otra cosa en esa fase, si el texto dice "al final de" sucede después de todo lo demás en esa fase y justo antes del inicio de la siguiente, si la hay. Después de que un jugador finalice su Noche, el siguiente jugador en sentido horario comienza su turno. El juego continúa hasta que un jugador gana la partida (`rule:3.1`).
         - name: Interrumpir.
           text: No puedes interrumpir una acción _(incluso una múltiple como la Marcha del Marquesado)_, habilidad _(como la Exposición de los Córvidos)_ o efecto persistente _(como la carta Emigrante del Nido)_ con otro efecto a menos que se permita explícitamente. _(Por ejemplo, la carta Pertrechados dice que se usa "En batalla...")_
     - name: Piezas
@@ -38,7 +39,7 @@
         - name: Límites.
           text: Las piezas están limitadas a las contenidas en el juego. No uses piezas de reemplazo si se agota alguna de ellas.
         - name: Facción Inicial.
-          text: Cada jugador controla a la facción que elija durante la preparación (5) y las piezas listadas en el dorso de su tablero de facción salvo los objetos. De forma genérica, estas se denominan **piezas de facción**. De forma específica, se denominan **piezas de [nombre de facción]**. _(Por ejemplo, "tus guerreros de facción" y "guerreros de tu facción" y "guuerreros del Marquesado", todos ellos se refieren a los guerreros de madera naranja con forma de gato)_.
+          text: Cada jugador controla a la facción que elija durante la preparación (5) y las piezas listadas en el dorso de su tablero de facción salvo los objetos. De forma genérica, estas se denominan **piezas de facción**. De forma específica, se denominan **piezas de [nombre de facción]**. _(Por ejemplo, "tus guerreros de facción" y "guerreros de tu facción" y "guerreros del Marquesado", todos ellos se refieren a los guerreros de madera naranja con forma de gato)_.
         - name: Pertenencia de las piezas.
           text: El propietario de las piezas de una facción no puede cambiar. _(Por ejemplo, el Marquesado no puede usar sus hospitales de Campaña con los secuaces o los mercenarios de la Compañía, ya que no son guerreros del Marquesado)_.
         - name: Manejo de las piezas.
@@ -62,7 +63,7 @@
             - name: Sustitución inversa.
               text: Si se te pide que gastes, descartes, tomes o des una carta de ave, no puedes sustituir esta carta por una de otro palo.
         - name: Cartas de Emboscada.
-          text: Hay cinco **cartas de emboscada**: un ratón, un conejo, un zorro y dos aves. Puedes gastar una carta de emboscada por su palo, pero no puedes fabricarla. También puedes jugar una en batalla para dar golpes (`rule:4.3.1`)."
+          text: "Hay cinco **cartas de emboscada**: un ratón, un conejo, un zorro y dos aves. Puedes gastar una carta de emboscada por su palo, pero no puedes fabricarla. También puedes jugar una en batalla para dar golpes (`rule:4.3.1`)."
         - name: Cartas de Dominancia.
           text: Hay cuatro **cartas de dominancia** que se corresponden con los cuatro palos. Puedes gastar una carta de dominancia por su palo, pero no puedes fabricarla. También puedes jugar una para cambiar de forma permanente tu condición de victoria (`rule:3.3`).
 
@@ -404,7 +405,7 @@
               subchildren:
                 - name: Ley Marcial.
                   text: Debes gastar un simpatizante correspondiente adicional si el claro elegido tiene al menos 3 guerreros de otro jugador, incluyendo guerreros que se estén tratando como suyos para gobernar _(mercenarios, secuaces, etc.)_.
-            - name: "Paso 3 Colcoar y Puntuar."
+            - name: "Paso 3: Colocar y Puntuar."
               text: Coloca una ficha de simpatía en el claro elegido. Obtén los puntos de victoria indicados en el espacio que acabas de revelar en tu tablero de facción.
 
     - name: Día
@@ -415,7 +416,7 @@
         - name: Mobilizar.
           text: Añade una carta de tu mano al montón de simpatizantes.
         - name: Entrenar.
-          text: Gasta una carta correspondeinte al palo indicado por una base en el mapa para colocar un guerrero en la zona de oficiales. Este guerrero ahora es un **oficial**.
+          text: Gasta una carta correspondiente al palo indicado por una base en el mapa para colocar un guerrero en la zona de oficiales. Este guerrero ahora es un **oficial**.
 
     - name: Noche
       pretext: Tu Noche tiene dos pasos en el siguiente orden.
@@ -434,141 +435,141 @@
         - name: Robar y Descartar.
           text: Roba una carta, más una carta adicional por cada símbolo de robo adicional descubierto. Entonces, si tienes más de cinco cartas en tu mano, descarta cartas a tu elección hasta quedarte con cinco.
 
-- name: Vagabundo
+- name: El Vagabundo
   color: "#6d6e70"
   icon: vagabond
   children:
     - name: Resumen
-      pretext: El Vagabundo juega con todos los bandos de este conflicto, mientras lleva a cabo sus propias misiones para aumentar su reputación. Cada vez que el Vagabundo mejora su  **relación** con otra facción o retira un guerrero de una facción Hostil, obtiene puntos de victoria. También puede obtener puntos de victoria completando sus **misiones**. Para moverse y realizar acciones, el Vagabundo deberá gestionar adecuadamente sus  **objetos**, procurando expandir su equipamiento mediante la exploración de las ruinas del bosque y ayudando a otras facciones.
+      pretext: El Vagabundo puede apoyar a todos los bandos de este conflicto, al tiempo que lleva a cabo misiones para incrementar su reputación. Cada vez que mejoras tu **relación** con otra facción, o bien quitas un guerrero que pertence a una facción hostil, obtienes puntos de victoria. También puedes completar **misiones** para obtener puntos de victoria. Para mover y actuar de forma efectiva con el Vagabundo debes gestionar tu hatillo de **objetos**, expandiendo tu colección al explorar las ruinas en los claros y ayudar a otras facciones.
     
     - name: Reglas y Habilidades de Facción
       children:
         - name: Fabricar.
-          text: Para fabricar objetos, el Vagabundo debe agotar `item:hammer`. Todos sus `item:hammer` siempre corresponden al palo en que esté situado el Vagabundo. Si fabrica un objeto, el Vagabundo toma el objeto de la reserva y lo coloca en su tablero bocarriba de forma inmediata.
-        - name: Errante solitario.
-          text: El Peón del Vagabundo no es un guerrero _(por lo que no cuenta a efectos de gobernar claros)._ El Peón del Vagabundo no puede ser retirado del mapa.
+          text: El Vagabundo agota `item:hammer` para fabricar. Todos sus `item:hammer` son correspondientes a su claro actual. Si el Vagabundo fabrica un objeto, puede tomarlo inmediatamente, bocarriba.
+        - name: Errante y Solitario.
+          text: El peón del Vagabundo no es un guerrero, así que no puede gobernar un claro o impedir que otro jugador gobierne uno. El peón del Vagabundo no puede retirarse del mapa.
           subchildren:
-            - name: Efectos de retirada total.
-              text: Cuando un jugador enemigo juegue un efecto que indique que se deben retirar todas las piezas enemigas de un claro _(como las revueltas de la Alianza, las cartas de Favor o las bombas de la Conspiración de los Córvidos)_ en el claro donde esté el Vagabundo, el Vagabundo debe dañar tres objetos.
+            - name: Retirada Total.
+              text: Cuando un jugador enemigo utilice un efecto que indique que se retiran todas las piezas enemigas de un claro _(como una revuelta de la Alianza, una carta del Favor de los Ratones o una bomba de los Córvidos)_ en el que está el Vagabundo, el Vagabundo daña tres de sus objetos a su elección.
 
         - name: Grácil.
-          text: El Vagabundo puede mover independientemente de quién gobierne el claro de origen o de destino.(`rule:4.2.1`).
+          text: El Vagabundo puede moverse independientemente de quién gobierne su claro de origen o de destino.(`rule:4.2.1`).
         - name: Indefenso.
-          text: En batalla, el Vagabundo está indefenso (`rule:4.3.2.3`) si no tiene ninguna `item:sword` no dañada.
+          text: En batalla, el Vagabundo está indefenso (`rule:4.3.2.3`) si no tiene `item:sword` no dañadas.
         - name: Objetos.
-          text: El potencial de acción del Vagabundo depende de los objetos que obtenga. Los objetos del Vagabundo pueden estar bocarriba o bocabajo su el tablero. Para realizar acciones Vagabundo **agota** sus objetos no dañados y no agotados, volteándolos bocabajo _(a su reverso de color oscuro)_.
+          text: Las capacidades del Vagabundo dependen de los objetos que tenga. En lugar de una zona para Objetos Fabricados tiene un Hatillo y varios contadores. Los objetos en el tablero de facción del Vagabundo pueden estar bocarriba o bocabajo. El Vagabundo **agota** objetos no dañados, volteándolos bocabajo, para hacer muchas de sus acciones.
           subchildren:
-            - name: Contadores de objetos.
-              text: Al obtener `item:tea`, `item:coin`, and `item:sack`, estos se colocan sobre las casillas de sus respectivos contadores. Cada contador puede contener un máximo de tres objetos de ese tipo.
-            - name: Hatillo.
-              text: Al obtenerlos, las `item:boot`, `item:sword`, `item:crossbow`, `item:torch`, y los `item:hammer` deben colocarse bocarriba en el Hatillo del Vagabundo.
-            - name: Mover objetos.
-              text: El Vagabundo puede intercambiar libremente sus  `item:tea`, `item:coin`, y `item:sack` no dañados bocarriba de sus contadores a su Hatillo.
-        - name: Impactos máximos por dados en batalla.
-          text: En batalla, el Vagabundo solo puede infligir tantos impactos por dados (`rule:4.3.2.1`) como `item:sword` no dañadas tenga en su Hatillo, tanto  tanto bocarriba como bocabajo _(los impactos adicionales que puedan causar otros efectos se suman después)_.
-        - name: Recibir impactos.
-          text: Cuando el Vagabundo recibe un impacto (`rule:4.3.3`), debe dañar un objeto no dañado, trasladándolo a su casilla de objetos dañados. En caso de que no queden objetos por dañar, el Vagabundo ignora los impactos restantes.
-        - name: Cartas de Dominancia y coaliciones.
-          text: En partidas de 4 o más jugadores, el Vagabundo puede activar una carta de Dominancia para formar una coalición con el jugador con menos puntos de victoria (sin contarse a sí mismo), indicándolo colocando para ello su contador de puntos de victoria en el tablero de la facción coaliada. En caso de que hubiera un empate entre facciones, entonces el Vagabundo decide con quién coaliarse. Si dicho jugador coaliado gana la partida, el Vagabundo también ganará. _(Al hacer esto, el Vagabundo ya no sumará puntos de victoria. No es posible formar una coalición con un jugador que haya jugado una carta de dominancia, puesto que este tampoco aspira a ganar por puntos)_
+            - name: Contadores.
+              text: Al obtenerlos o al voltearlos bocarriba, coloca `item:tea`, `item:coin`, y `item:sack` bocarriba en sus contadores. Cada contador puede tner hasta 3 objetos del mismo tipo.
+            - name: El Hatillo.
+              text: Al obtenerlos, coloca `item:boot`, `item:sword`, `item:crossbow`, `item:torch`, y `item:hammer` bocarriba en el hatillo.
+            - name: Mover Objetos.
+              text: El Vagabundo puede mover libremente `item:tea`, `item:coin`, y `item:sack` entre sus contadores y el hatillo, siempre y cuando estén bocarriba y no dañados.
+        - name: Golpes Máximos por Tirada.
+          text: En batalla, sus golpes máximos por tirada (`rule:4.3.2.1`) son iguales a sus `item:sword` no dañadas, bocarriba o bocabajo, en su hatillo.
+        - name: Recibir Golpes.
+          text: Cuando el Vagabundo recibe un golpe (`rule:4.3.3`), debe dañar uno de sus objetos no dañados, moviéndolo a su zona de dañados. Si no le quedan objetos no dañados, el Vagabundo ignora cualquier golpe restante.
+        - name: Cartas de Dominancia y Coaliciones.
+          text: El Vagabundo no puede activar la condición de victoria de una carta de dominancia (`rule:3.3.1`). En vez de eso, en partidas de cuatro jugadores o más, el Vagabundo puede activar una carta de dominancia para formar una coalición con otro jugador, colocando su marcador de puntuación en el tablero de dicho jugador _(el Vagabundo ya no obtiene más puntos de victoria)_. Dicho jugador debe ser el que menos puntos de victoria tenga, salvo por el Vagabundo que forma coalición con él, y no puede estar ya en una coalición. Si hay un empate en la posición de menos puntos, elige a uno de los jugadores empatados. Si el jugador elegido gana la partida, el Vagabundo también gana.
         - name: Relaciones.
-          text: El tablero de facción del Vagabundo muestra una tabla de Relaciones, que muestra un contador de Aliado con cuatro espacios y una casilla con la denominación de Hostil. En esta tabla se coloca un marcador de relación para cada facción en juego que no sea un Vagabundo.
+          text: Tu tablero de facción muestra una tabla de relaciones que tiene cuatro espacios en la sección de aliados y una zona de hostiles. Contiene un marcador de relación por cada facción que no es el Vagabundo.
           subchildren:
-            - name: Mejorar relaciones.
-              text: Puedes mejorar tu relación con el jugador de una facción no Hostil realizando la acción de Ayudar.
+            - name: Mejorar Relaciones.
+              text: Puedes mejorar las relaciones con una facción no hostil llevando a cabo la acción ayudar.
               subchildren:
                 - name: Coste.
-                  text: Ayuda a una facción no Hostil tantas veces como indique el icono de la tabla de relaciones para avanzar a la siguiente casilla durante el mismo turno. _(Una acción de Ayudar solo cuenta una vez a efectos de mejorar relaciones)_
+                  text: Ayuda a una facción no hostil en un mismo turno el número de veces que aparece entre el espacio que contiene su marcador de relación y el siguiente espacio. _(Una acción de ayuda sólo cuenta para una mejora de relaciones)_.
                 - name: Efecto.
-                  text: Avanza el marcador de relación de dicha facción una casilla a la derecha sobre la tabla. Suma los puntos de victoria indicados en la nueva casilla.
+                  text: Avanza el marcador de relación de esa facción un espacio hacia la derecha en el contador. Obtén los puntos de victoria anotados en el nuevo espacio.
             - name: Estatus de Aliado.
-              text: Si el marcador de relación de una facción alcanza la última casilla de la tabla de Relaciones, a partir de ese momento tú y el jugador que controla dicha facción sois **Aliados**, como indica el marcador de relación. _(¡Ahora sus guerreros confían en ti y puedes luchar con ellos!)_
+              text: Si el marcador de relación de una facción llega al espacio final del contador estás **aliado** con esa facción. _(¡Sus guerreros confían en ti!)_.
               subchildren:
                 - name: Ayudar a un Aliado.
-                  text: Cada vez que ayudas a un jugador Aliado, obtienes 2 puntos de victoria _(en lugar de 1)_.
+                  text: Cada vez que ayudes a una facción aliada, obtienes dos puntos de victoria.
                 - name: Mover con un Aliado.
-                  text: Al mover de un claro a otro, también puedes mover guerreros de un jugador Aliado desde el claro de origen al claro de destino.
+                  text: Cuando te muevas a un claro adyacente, también puedes forzar a guerreros de una facción aliada a moverse desde tu claro de origen a tu claro de destino acompañando a tu peón de Vagabundo.
                 - name: Atacar con un Aliado.
-                  text: Cuando inicies una batalla, puedes tratar los guerreros de un jugador Aliado de dicha claro como si fuesen tuyos. El máximo de impactos que podrás causar (teniendo en cuenta el límite del valor del dado) estará entonces limitado por el número de guerreros aliados más tus `item:sword` no dañadas totales. No obstante, no puedes tratar los guerreros aliados como si fuesen tuyos en batalla si tú eres el defensor.
-                - name: Recibir impactos junto a un Aliado.
-                  text: En una batalla en la que trates a guerreros Aliados como si fuesen tuyos, puedes recibir impactos sobre ellos, retirando dichos guerreros Aliados. No obstante, debes repartir los impactos; si al recibir impactos en batalla retiras más guerreros Aliados que objetos tuyos dañas, tu Aliado se volverá Hostil. Esta regla prevalece la condición para volverse Hostil del apartado 9.2.9.III.
-            - name: Condición de Hostil.
-              text: Si alguna vez retiras un guerrero de una facción no Hostil, mueve inmediatamente el marcador de relación correspondiente a dicha facción a la casilla de "Hostil". Dicha facción es ahora **Hostil**.
+                  text: Cuando inicies una batalla, puedes tratar a los guerreros de una facción aliada en el claro de batalla como si fueran tuyos. Tus golpes máximos por tirada son iguales a la suma de dichos guerreros más el total de `item:sword` no dañadas. No puedes tratar a dichos guerreros como tuyos si atacas a esa misma facción aliada.
+                - name: Recibir Golpes con un Aliado.
+                  text: En una batalla donde tratas guerreros aliados como tuyos, puedes recibir golpes retirando a esos guerreros. Sin embargo, si recibes más golpes retirando guerreros aliados que dañando objetos durante la misma batalla, esa facción aliada se vuelve hostil (`rule:9.2.9.3`) al final de la batalla. Esta regla suprime la condición para hacerse hostil en `rule:9.2.9.3`.
+            - name: Estatus Hostil.
+              text: Si retiras un guerrero de una facción no hostil, mueve su marcador de relación inmediatamente a la zona de hostil. Esta facción es ahora **hostil**. Después, si esto sucede en una batalla durante tu turno, comprueba la puntuación por Infamia (`rule:9.2.9.3.1`).
               subchildren:
                 - name: Infamia.
-                  text: Cada vez que retires una pieza de una facción Hostil en batalla durante tu turno, obtienes un punto de victoria. _(Ello se suma a los puntos obtenidos por retirar fichas y edificios enemigos. No obtienes un punto por retirar el guerrero que causa que dicha facción se vuelva Hostil)_
-                - name: Mover a un claro Hostil.
-                  text: Debes agotar una `item:boot` extra para mover a un claro que contenga guerreros de cualquier facción Hostil _(excepto si lo haces al **infiltrarte** durante tu Alba)_.
-                - name: Ayudar a una facción Hostil.
-                  text: No puedes mejorar tu relación con una facción Hostil mediante la acción de Ayuda, pero sí es posible ayudar a una facción Hostil para coger sus objetos fabricados.
-                - name: Coalición con una facción Hostil.
-                  text: Puedes formar una coalición (`rule:9.2.8`) con una facción Hostil. Si lo haces, coloca el marcador de relación correspondiente sobre la casilla de "Indiferente".
+                  text: Obtienes un punto de victoria adicional por cada pieza de una facción hostil que retires en batalla durante tu turno, salvo por el guerrero que convirtió a esa facción en hostil. _(Suma estos puntos a los obtenidos por retirar edificios y fichas enemigas)_.
+                - name: Mover a Claros Hostiles.
+                  text: Debes agotar una `item:boot` adicional para moverte a un claro con cualquier número de guerreros de cualquier número de facciones hostiles.
+                - name: Ayudar a Facciones Hostiles.
+                  text: No puedes mover un marcador de relación fuera de la zona de hostiles utilizando la acción ayudar, pero aún puedes ayudar a una facción hostil para obtener objetos fabricados.
+                - name: Coalición con Facciones Hostiles.
+                  text: Puedes formar una coalición (`rule:9.2.8`) con una facción hostil. Si lo haces, mueve su marcador de relación al espacio de indiferente.
 
-    - name: Preparación Individual
+    - name: Preparación
       children:
-        - name: "Paso 1: Personaje."
-          text: Elige una carta de personaje y colócala sobre el hueco correspondiente de tu tablero.
-        - name: "Paso 2: Peón de Vagabundo."
-          text: Coloca tu peón de Vagabundo sobre cualquier bosque del mapa.
-        - name: "Paso 3: Misiones iniciales."
-          text: Baraja tu mazo de misiones, roba 3 cartas de misión y colócalas bocarriba en tu área de juego.
-        - name: "Paso 4: Preparar Ruinas."
-          text: Coge las 4 piezas de las Ruinas del mapa, y los 4 objetos marcados con una "R" (`item:sack`, `item:boot`, `item:hammer`, y `item:sword`). Coloca 1 de estos objetos bajo cada Ruina al azar, y después mezcla los cuatro montones formados. Después, coloca, al azar, cada Ruina con su ficha de objeto debajo sobre las correspondientes casillas del mapa.
-        - name: "Paso 5: Objetos iniciales (\"S\")."
-          text: Coge los objetos que indica tu carta personaje de la reserva de objetos marcados con una "S" _(este conjunto de objetos solo se utiliza durante la preparación)_. Coloca cualquier `item:tea`, `item:coin`, y`item:sack` indicado bocarriba sobre su correspondiente contador de tu tablero. Coloca el resto de objetos bocarriba en tu Bolsa. Finalmente, devuelve el resto de objetos marcados con una "S" a la caja.
-        - name: "Paso 6: Relaciones."
-          text: Coge los marcadores de relación correspondientes a cada facción que no sea el Vagabundo y y colócalos sobre la casilla "Indiferente" de la tabla de Relaciones.
+        - name: "Paso 1: Elegir un Personaje."
+          text: Elige una carta de personaje y colócala en tu espacio de carta de personaje.
+        - name: "Paso 2: Colocar el Peón."
+          text: Coloca tu peón de Vagabundo en un bosquer a tu elección.
+        - name: "Paso 3: Conseguir Misiones."
+          text: Baraja tu mazo de misiones, roba 3 cartas de misión y colócalas bocarriba junto a ti.
+        - name: "Paso 4: Llenar las Ruinas."
+          text: Toma las 4 piezas de las ruinas del mapa, y toma los objetos `item:sack`, `item:boot`, `item:hammer`, y `item:sword` marcados con una "R". Coloca uno bajo cada ruina y entonces repártelas al azar entre los espacios vacíos de ruina del mapa.
+        - name: "Paso 5: Obtener los Objetos Iniciales"
+          text: Toma los objetos marcados con una "S" que aparecen en tu carta de personaje. Coloca los objetos `item:tea`, `item:coin`, y`item:sack` indicados bocarriba en los contadores correspondientes de tu tablero. Coloca bocarriba los demás objetos indicados en tu hatillo. Devuelve cualquier objeto "S" restante a la caja.
+        - name: "Paso 6: Configurar Relaciones."
+          text: Toma el marcador de relación de cada facción que no sea Vagabundo y colócalo en el espacio de indiferente de tu contador de relaciones.
 
     - name: Alba
-      pretext: Tu Alba tiene 2 pasos en el siguiente orden.
+      pretext: Tu Alba tiene dos pasos en el siguiente orden.
       children:
-        - name: Reactivar objetos.
-          text: Voltea 2 objetos agotados bocarriba por cada `item:tea` bocarriba que tengas al inicio de tu Alba. Después, reactiva hasta 3 objetos agotados más.
+        - name: Refrescar.
+          text: Al inicio de tu Alba da la vuelta a dos objetos agotados  `item:tea` que esté bocarriba en su contador. Luego, pon bocarriba tres objetos agotados más.
         - name: Infiltrarse.
-          text: Puedes mover a un claro o bosque adyacente sin agotar ninguna `item:boot`, incluso si mueves hacia un claro Hostil (`rule:9.2.9.3.2`). Este movimiento ignora todos los efectos que prohíben moverse desde un claro _(como la trampa de los Córvidos)_.
+          text: Puedes moverte a un bosque o claro adyacente sin agotar `item:boot`, incluso para moverte a un claro hostil (`rule:9.2.9.3.2`). Este movimiento ignora todos los efectos que previenen el movimiento de salida de un claro _(como el cepo de los Córvidos)_.
 
     - name: Día
-      pretext: Puedes agotar objetos para realizar las acciones siguientes, en cualquier orden y combinación. En caso de agotar `item:coin`, `item:tea`, o `item:sack` de un contador, deberás mover dicho objeto al Hatillo.
+      pretext: Puedes agotar objetos para realizar las acciones siguientes, en cualquier orden y número. Si agotas un `item:coin`, `item:tea`, o `item:sack` de un contador, muévelo a tu hatillo.
       children:
         - name: Mover.
-          text: Agota una `item:boot` para realizar un movimiento, más una adicional si el claro de destino tiene guerreros de alguna facción Hostil. No es posible mover a un bosque _(esto solo es posible durante el movimiento de infiltración de tu Alba)_. Si estás en un bosque, solo puedes mover a un claro adyacente.
+          text: Agota una `item:boot` para moverte y una `item:boot` adicional si tu claro de destino contiene guerreros hostiles. No puedes moverte a un bosque. Si estás en un bosque, solo puedes moverte a un claro adyacente.
         - name: Batallar.
-          text: Agota una `item:sword` para iniciar una batalla. _(Comprueba tu luego relación con el defensor, ya que se volverá Hostil si no lo era ya)_
+          text: Agota una `item:sword` para iniciar una batalla. _(Comprueba tu relación con el defensor)_.
         - name: Explorar.
-          text: Agota una `item:torch` para extraer un objeto de una ruina del claro actual, revelándolo y colocándolo en tu Bolsa o sobre su contador, según corresponda. Después, suma 1 punto de victoria. Si al hacer esto retiras el último objeto de una ruina, retira la ruina del claro.
+          text: Agota una `item:torch` para tomar un objeto de debajo de una ruina en tu claro actual, revélalo y colócalo bocarriba en tu hatillo o en su contador correspondiente. Si tomas un objeto, obtienes un punto de victoria. Si retiras el último objeto de una ruina, retira la ruina del mapa.
         - name: Ayudar.
-          text: Agota cualquier objeto, y dale una carta del palo correspondiente al claro a cualquier jugador que tenga al menos una pieza en dicho claro _(incluso si es Hostil)_. Después, puedes coger un objeto de la zona de objetos fabricados del tablero de dicho jugador, si tiene; si lo haces, colócalo sobre tu Hatillo o sobre su respectivo contador, según corresponda. _(Luego, comprueba si se modifica tu relación con dicha facción)_
+          text: Agota cualquier objeto, y entrega una de tus cartas correspondientes a tu claro a cualquier jugador con piezas de facción allí _(incluso si es hostil)_. Luego, puedes tomar un objeto de la zona de objetos fabricados de ese jugador, si tiene, y colocarlo bocarriba en tu hatillo o en su contador correspondiente _(comprueba tu relación con la facción de ese jugador)_.
         - name: Misión.
-          text: Elige una misión del palo correspondiente al claro en el que estés, y agota los dos objetos indicados en la carta para completarla. Coloca dicha misión completada en tu área de juego y luego revela una nueva carta de misión, colocándola junto al mapa. Suma 1 punto de victoria por cada misión de dicho palo que hayas completado, contando con la que acabas de completar, o bien roba dos cartas del mazo.
-        - name: Disparar.
-          text: Agota una `item:crossbow` para retirar un guerrero situado en tu claro actual. Si un jugador no tiene guerreros en este claro, puedes retirar en su lugar una ficha o edificio de dicho jugador. _(Luego, comprueba si se modifica tu relación con dicha facción. Ten en cuenta que esta acción no cuenta como batalla, por lo que no se obtienen puntos por Infamia al retirar piezas de un jugador Hostil.)_
-        - name: Repair.
-          text: Agota un `item:hammer` para trasladar un objeto dañado a tu Hatillo o a su correspondiente contador _(en caso de tratarse de `item:coin`, `item:tea`, `item:sack` bocarriba, no agotados)_, manteniendo el objeto en su estado de uso actual.
+          text: Elige una misión correspondiente a tu claro y agota los dos objetos indicados en dicha misión para completarla. Coloca la misión en tu zona de juego y luego revela una nueva misión. Puedes obtener un punto de victoria por cada misión correspondiente que hayas realizado, incluida esta última, o bien robar dos cartas del mazo.
+        - name: Golpear.
+          text: Agota una `item:crossbow` para retirar a un guerrero enemigo de tu claro. Si ese enemigo no tiene guerreros en ese claro puedes retirar una de sus otras piezas de facción allí en su lugar _(comprueba tu relación con la facción de ese jugador)_.
+        - name: Reparar.
+          text: Agota un `item:hammer` para mover un objeto dañado a tu hatillo _(si es `item:boot`, `item:hammer`, `item:sword`, `item:crossbow` o `item:torch`)_ o a su contador desde tu hatillo _(si es `item:coin`, `item:tea`, `item:sack` si está bocarriba)_. En cualquier caso, no le des la vuelta al objeto.
         - name: Fabricar.
-          text: Juega una carta de tu mano, agotando `item:hammer` para fabricarla. Todos tus `item:hammer` siempre corresponden al palo de tu claro actual. Si una carta requiere varias piezas de fabricación, debes agotar tantos `item:hammer` como indique la carta para fabricarla. Si fabricas un objeto, colócalo bocarriba directamente en tu Hatillo o sobre su correspondiente contador, según corresponda.
-        - name: Acción especial.
-          text: Agota una `item:torch` para realizar la acción especial descrita en tu carta de personaje.
+          text: Juega una carta de tu mano y agota el correspondiente `item:hammer` para fabricarla. Todos tus `item:hammer` se corresponden con tu claro. Si una carta requiere más de una activación de un mismo palo para poder ser fabricada, debes agotar el número requerido de `item:hammer`. Si fabricas un objeto, puedes colocarlo bocarriba en tu hatillo o en su contador.
+        - name: Acción Especial.
+          text: Agota una `item:torch` para realizar la acción indicada en tu carta de personaje.
 
     - name: Noche
-      pretext: Tu Noche tiene 4 Pasos en el siguiente orden.
+      pretext: Tu Noche tiene cuatro pasos en el siguiente orden.
       children:
-        - name: Descanso nocturno forestal.
-          text: Si estás en un bosque, repara y refresca todos tus objetos, colocándolos bocarribaen tu Bolsa o sobre su correspondiente contador _(ello implica que te has quedado en el bosque durante tu Alba, por lo que salvo excepciones no habrás realizado acciones en tu Día)_.
-        - name: Robar cartas.
-          text: Roba una carta, más una carta adicional por cada `item:coin` bocarriba en su correspondiente contador.
-        - name: Descartar cartas.
-          text: Si tienes más de 5 cartas en la mano, descarta cartas a tu elección hasta tener solo 5.
-        - name: Comprobar límite de objetos.
-          text: Si entre tu zona de objetos dañados y tu Hatillo tienes más objetos de los permitidos —el límite son 6 más 2 por cada `item:sack` bocarriba en su correspondiente contador— descarta objetos de tu bolsa o de tu zona de objetos dañados hasta tener la cantidad máxima permitida y retíralos permanentemente del juego.
+        - name: Descansar.
+          text: Si estás en un bosque mueve todos tus objetos de tu zona de dañados a tu hatillo o a su contador, y gíralos bocarriba.
+        - name: Robar Cartas.
+          text: Roba una carta, más una carta adicional por cada `item:coin` bocarriba en su contador.
+        - name: Descartar Cartas.
+          text: Si tienes más de cinco cartas en tu mano, descarta cartas a tu elección hasta quedarte con cinco.
+        - name: Comprobar Capacidad.
+          text: Si tienes mṕas objetos en total en tu hatillo y tu zona de dañados que tu límite de objetos _(seis más dos por cada `item:sack` bocarriba en su contador)_ retira objetos de tu hatillo o zona de dañados hasta quedarte con un número de objetos igual a tu límite y devuélvelos a la caja.
 
-    - name: Jugar con dos Vagabundos
-      subtext: Si tienes la expansión de _Los Ribereños_, puedes jugar partidas con dos Vagabundos aplicando las reglas siguientes.
+    - name: Jugar con Dos Vagabundos
+      subtext: Si tienes la expansión _Los Ribereños_, puedes jugar una partida con dos Vagabundos siguiendo estas reglas.
       children:
-        - name: Añade un objeto extra a las Ruinas.
-          text: Durante la preparación, utiliza los dos conjuntos de objetos "R", y coloca dos objetos de "R" debajo de cada Ruina. Cuando un vagabundo explore una Ruina en la que haya dos objetos, puede mirar ambos objetos y elegir el que prefiera. No es posible coger un objeto "R" que coincida con otro objeto "R" que ya tenga sobre su tablero de facción _(así pues si realizas dos acciones de Explorar, es posible coger los dos objetos de dicha Ruina, siempre que sean diferentes)_. En caso de explorar pero no coger el objeto, no obtienes un punto de victoria, pero la antorcha queda agotada igualmente.
-        - name: Orden de preparación.
-          text: Determina al azar qué Vagabundo realizará su preparación primero.
-        - name: Misiones compartidas.
-          text: Cualquiera de los dos Vagabundos puede completar cualquiera de las tres misiones reveladas. No se añaden cartas extra durante la preparación.
+        - name: Preparación.
+          text: Usa los dos grupos de objetos "R" y coloca dos objetos al azar "R" bajo cada ficha de ruinas. Si usas la Preparación Estándar (`rule:5.1`), determina al azar qué Vagabundo hace su preparación antes.
+        - name: Misiones Compartidas.
+          text: Cualquiera de los Vagabundos puede completar cualquiera de las tres misiones bocarriba. No añadas cartas de misión adicionales durante la preparación.
+        - name: Tomando Objetos de las Ruinas
+          text: Cuando un Vagabundo explora una ruina con dos objetos, o Los Cientos arrasan una ruina (`rule:14.4.1`) con dos objetos, ese jugador puede ver esos objetos y escoger uno. _(Realizando dos acciones de Explorar, el Vagabundo podría tomar ambos objetos de una ruina)_. Un jugador no puede tomar un objeto "R" si ya tiene el mismo tipo de objeto "R" en su tablero de facción. _(Si el Vagabundo explora pero no toma el objeto, no obtiene un punto de victoria, pero la `item:torch` se agota igualmente)_.
 
 - name: El Culto Reptiliano
   color: "#fcf065"

--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -751,120 +751,93 @@
   icon: duchy
   children:
     - name: Resumen
-      pretext: El Ducado Subterráneo pretende demostrar a las criaturas forasteras del Bosque que pueden ser sus gobernantes. Mientras establecen sus puestos fronterizos para mostrar su poder sobre el Bosque, el Ducado nombrará **ministros** para dirigir su causa, obteniendo puntos de victoria y desviando recursos para los propósitos del Ducado. Pero tened cuidad de que un giro de fortuna conduzca a la humillación pública, pues esto causará que los ministros abadonen su causa.
+      pretext: El Ducado Subterráneo quiere demostrarle a las extrañas criaturas del Bosque que estarían mejor como súbditos suyos. A medida que coloca puestos fronterizos para mostrar su poder en el Bosque, el Ducado puede convencer **ministros** para que sigan su causa, obteniendo puntos de victoria y desviando más y más recursos del Ducado. Pero tened cuidado, un revés de la fortuna podría suponer una humillación pública y llevar a los ministros a abandonar su tarea.
 
     - name: Reglas y Habilidades de Facción
       children:
         - name: Fabricar.
-          text: El Ducado Subterráneo fabrica durante la Noche activando Ciudadelas y Mercados.
-
+          text: El Ducado Subterráneo fabrica durante la Noche activando ciudadelas y mercados.
         - name: La Madriguera.
-          text: "**La Madriguera** es un claro no presente sobre el mapa, que se considera adyacente a cualquier claro en que haya una ficha de túnel. Este claro subterráneo es solo accesible al Ducado, así que solo el Ducado puede colocar piezas y mover guerreros a la Madriguera. El Ducado siempre gobierna la Madriguera, incluso si no tiene piezas en ella."
-
-        - name: El precio del fracaso.
-          text: Cuando cualquier cantidad de edificios del Ducado sean retirados, el Ducado debe descartar una carta al azar,  devolver su carta de ministro coronado de rango más alto _(lord > noble > hidalgo)_ a la pila de ministros no coronados y retirar la corona colocada sobre esta del juego permanentemente, devolviéndola a la caja. En caso de tener varios ministros del mismo rango, el Ducado elige cuál retirar.
-
+          text: La **madriguera** es un claro sin palo adyacente a cada claro que tiene una ficha de túnel. Ninguna pieza que no sea del Ducado se puede colocar o mover en la madriguera. El Ducado siempre gobierna la madriguera _(incluso si no tiene piezas allí)_.
+        - name: El Precio del Fracaso.
+          text: Siempre que se retiren cualquier número de edificios del Ducado, el Ducado descarta una carta al azar, devuelve su carta de ministro convencido de mayor rango _(primero lord, después noble, después escudero)_ a la pila de ministros sin convencer, y guarda su corona en la caja. Si tiene varios ministros convencidos del rango más alto, el Ducado elige cuál retira.
         - name: Túneles.
-          text: El Ducado tiene tres fichas de Túnel. Si el Ducado debiese colocar un túnel pero sus tres túneles ya están sobre el mapa, debes retirar primero cualquier ficha de túnel del mapa.
+          text: El Ducado tiene tres fichas de túnel. Si se le indica al Ducado que coloque un túnel y ya están los tres túneles sobre el mapa, el ducado puede retirar primero un túnel cualquiera del mapa.
 
-    - name: Preparación Individual
+    - name: Preparación
       children:
-        - name: "Paso 1: Guerreros any Túneles."
-          text: Pon en tu reserva tus 20 guerreros y 3 fichas de Túnel.
-
-        - name: "Paso 2: Madriguera."
-          text: Coloca el tablero de la Madriguera junto al mapa. 
-
-        - name: "Paso 3: Preparación inicial en superficie."
-          text: Coloca 2 guerreros y 1 túnel en un claro de una esquina el mapa que no contenga la fortaleza del Marquesado, el nido inicial del Nido de Águilas ni el jardín inicial del Culto Reptiliano, y que esté situado en la esquina opuesta a uno de dichos claros iniciales si es posible. Después, coloca 2 guerreros en cada claro adyacente a tu claro inicial pero no en la Madriguera.
-
-        - name: "Paso 4: Contadores de edificios."
-          text: Coloca 3 ciudadelas y 3 mercados sobre sus correspondientes casillas de los contadores de edificios tu tablero.
-
-        - name: "Paso 5: Ministros."
-          text: Coloca las 9 cartas de Ministro bocarriba junto al tu tablero, formando la pila de ministros no coronados.
-
-        - name: "Paso 6: Contadores de coronas."
-          text: Coloca 9 coronas sobre las casillas de los contadores que indican puntos de victoria de tu tablero de facción.
+        - name: "Paso 1: Juntar Guerreros y Túneles."
+          text: Forma la reserva de guerreros (20) y las fichas de túneles (3).
+        - name: "Paso 2: Preparar la Madriguera."
+          text: Coloca el tablero de la madriguera cerca del mapa. 
+        - name: "Paso 3: Salir a la Superficie."
+          text: Coloca 2 guerreros y 1 túnel en un claro en una esquina que no sea el claro inicial de otro jugador y, si es posible, que sea diagonalmente opuesto a un claro inicial. Éste es tu claro inicial. Después coloca 2 guerreros en cada claro adyacente al claro elegido, pero no en la madriguera. _(Esto se ha actualizado con respecto a ediciones anteriores por flexibilidad)_.
+        - name: "Paso 4: Rellenar los Marcadores de Edificios."
+          text: Coloca 3 ciudadelas y 3 mercados en los correspondientes espacios de edificios de tu tablero.
+        - name: "Paso 5: Recoger Ministros."
+          text: Coloca las 9 cartas de Ministro bocarriba en tu pila de ministros sin convencer.
+        - name: "Paso 6: Rellenar los Espacios de Coronas."
+          text: Coloca las 9 coronas en los espacios con puntos de victoria de tu tablero.
 
     - name: Alba
-      pretext: Coloca 1 guerrero, más otro guerrero por icono revelado, en la Madriguera.
+      pretext: Coloca un guerrero, más otro guerrero por icono de guerrero revelado en tu tablero, en la Madriguera.
       
     - name: Día
-      pretext: Tu Día tiene 3 pasos en el siguiente orden.
+      pretext: Tu Día tiene tres pasos en el siguiente orden.
       children:
         - name: Asamblea.
-          text: Puedes realizar hasta dos acciones, en cualquier orden y combinación, según se indica.
+          text: Puedes llevar a cabo hasta dos acciones en cualquier orden y número, de la forma siguiente.
           subchildren:
             - name: Construir.
-              text: Revela 1 carta para colocar una ciudadela o un mercado en un claro del palo correspondiente en que gobiernes.
-
+              text: Revela una carta para colocar una ciudadela o un mercado en un claro correspondiente que gobiernes.
             - name: Reclutar.
-              text: Coloca 1 guerrero en la Madriguera.
-
+              text: Coloca un guerrero en la madriguera.
             - name: Mover.
-              text: Realiza un movimiento.
-
+              text: Haz un movimiento.
             - name: Batallar.
               text: Inicia una batalla.
-
             - name: Excavar.
-              text: Gasta una carta para colocar una ficha de túnel sobre un claro del palo correspondiente en que no haya ya un túnel. Después, puedes mover hasta 4 guerreros de la madriguera a dicho claro. _(Si los tres túneles están sobre el mapa ya, deberás primero retirar un túnel para colocarlo en el nuevo claro)_
-
+              text: Gasta una carta para colocar una ficha de túnel en un claro correspondiente que no tenga una ficha de túnel. Entonces mueve hasta cuatro guerreros desde la madriguera a ese claro. _(Si los tres túneles están sobre el tablero, puedes retirar uno antes)_.
         - name: Parlamento.
-          text: Puedes realizar la acción de cada ministro coronado una vez, realizando estas acciones en el orden que desees.
+          text: Puedes llevar a cabo la acción de cada uno de los minsitros convencidos, una vez cada una en cualquier orden.
           subchildren:
-            - name: Capataz.
-              text: Revela cualquier carta para colocar una ciudadela o mercado en cualquier claro _(independientemente del palo)_ que gobiernes.
-
+            - name: Capatopo.
+              text: Revela cualquier carta para colocar una ciudadela o mercado en cualquier claro _(correspondiente o no)_ que gobiernes.
             - name: Capitán.
               text: Inicia una batalla.
-
-            - name: Mariscal.
-              text: Realiza un movimiento.
-
-            - name: General de Brigada.
-              text: Mueve o inicia batalla hasta dos veces.
-
+            - name: Alguacil.
+              text: HAz un movimiento.
+            - name: Brigada.
+              text: Haz hasta dos movimientos o inicia hasta dos batallas.
             - name: Banquero.
-              text: Gasta tantas cartas como desees _(puede ser solo una)_ de un mismo palo para puntuar tantos puntos como cartas gastes.
-
-            - name: Gobernador.
-              text: Realiza la acción de cualquier hidalgo o noble coronado.
-
+              text: Gasta cualquier número de cartas _(con un mínimo de una)_ del mismo palo para obtener ese mismo número de puntos de victoria.
+            - name: Alcalde.
+              text: Lleva a cabo la acción de cualquier noble o escudero convencidos.
             - name: Duquesa del Lodo.
-              text: Puntúa 2 puntos de victoria si los tres túneles están sobre el mapa.
-
-            - name: Barón del Fango.
-              text: Puntúa 1 punto de victoria por cada mercado que tengas en el mapa.
-
-            - name: Conde de las Rocas.
-              text: Puntúa 1 punto de victoria por cada ciudadela que tengas en el mapa..
-
-        - name: Coronar Ministros.
-          text: Puedes coronar un ministro, siguiendo las instrucciones siguientes.
+              text: Obtén dos puntos de victoria si los trestúneles están sobre el mapa.
+            - name: Barón de la Tierra.
+              text: Obtén un punto de victoria por cada mercado que haya sobre el mapa.
+            - name: Conde de la Piedra.
+              text: Obtén un punto de victoria por cada ciudadela que haya sobre el mapa.
+        - name: Convencer.
+          text: Puedes convencer a un ministro, de lña siguiente forma.
           subchildren:
-            - name: Elige ministro.
-              text: Elige una carta de ministro de la pila de Ministros no coronados. Debes tener en tu tablero de facción una corona del rango correspondiente a dicho ministro _(hidalgo, noble o lord)_ disponible sobre su correspondiente contador.
-
-
-            - name: Revela cartas.
-              text: Revela tantas cartas como indique la carta de ministro elegida. Por cada carta que desees revelar, debes tener al menos una pieza en un claro del palo de dicha carta. Cada claro en el que tengas al menos una pieza te permite revelar pues 1 carta de dicho palo.
-
-            - name: Coronar ministro y puntuar.
-              text: Toma la carta de ministro elegida y colócala en tu tablero de facción. Toma la corona correspondiente al rango del dicho ministro de tu tablero _(siempre la primera disponible de su correspondiente contador)_ y colócala sobre la carta de ministro. Suma los puntos de victoria que indica la casilla recién descubierta de tu tablero de facción.
+            - name: Elegir Ministro.
+              text: Elige una carta de ministro de tu pila de ministros no convencidos. Debes tener una corona en tu tablero de facción del rango correspondiente _(escudero, noble o lord)_ a dicho ministro.
+            - name: Revelar Cartas.
+              text: Revela el número de cartas que aparece en el ministro elegido. Por cada carta que desees revelar, debes tener al menos una pieza del Ducado en un claro correspondiente al palo de esa carta. Cada claro con alguna pieza del Ducado sólo te permite revelar una carta correspondiente.
+            - name: Convencer al Ministro y Puntuar.
+              text: Toma la carta del ministro elegido y colócala sobre tu tablero de facción. Toma una corona 0del rango de ese ministro de tu tablero y colócala sobre la carta del ministro. Obtén el número de punts de victoria que aparecen en el espacio que acabas de descubrir en tu tablero.
 
     - name: Noche
-      pretext: Tu Noche tiene 3 pasos en el siguiente orden.
+      pretext: Tu Noche tiene tres pasos en el siguiente orden.
       children:
-        - name: Descartar y recuperar las cartas reveladas.
-          text: Discard any bird cards you revealed this turn, then return all other cards you revealed this turn to your hand.
-
+        - name: Descartar y Devolver Cartas Reveladas.
+          text: Descarta cualquier cantidad de cartas de ave que hayas revelado este turno, despuṕes devuelve todas las demás cartas reveladas a tu mano.
         - name: Fabricar.
-          text: Puedes fabricar activando ciudadelas y mercados. _(A efectos de fabricar, estas piezas son idénticas)_
-
-        - name: Robar y descartar.
-          text: Roba 1 carta, más 1 carta por cada icono de robar revelado en tu tablero. Después, si tienes más de 5 cartas en tu mano, descarta cartas a tu elección hasta tener solo 5.
+          text: Puedes fabricar cartas de tu mano activando ciudadelas y mercados _(son idénticos a efectos de fabricación)_.
+        - name: Robar y Descartar.
+          text: Roba una carta, más una carta adicional por cada símbolo de robo adicional descubierto. Entonces, si tienes más de cinco cartas en tu mano, descarta a tu elección hasta quedarte con cinco.
 
 - name: La Conspiración de los Córvidos
   color: "#925da5"

--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -1282,3 +1282,74 @@
               text: Los lugares míticos no pueden ser movidos o retirados, ni se puede batallar contra ellos, a menos que se indique expresamente en el lugar mítico.
             - name: Pertenencia.
               text: Los lugares míticos no son propiedad de ninguna facción y no son piezas enemigas.
+
+    - name: Glossary
+      children:
+        - name: Adyacente.
+          text: Un claro es adyacente a otro claro si está unido a él por un camino. Un bosque es adyacente a todos los claros que lo tocan sin atravesar un camino, y es adyacente a todos los bosques que están separados únicamente por un camino, salvo en el lago (`rule:16.2.2`). `faction:duchy:12.2.2`
+        - name: Borde del tablero o mapa.
+          text: Línea única cerrada de claros y caminos que define los límites del mapa, incluyendo los caminos cerrados en el mapa de la montaña.
+        - name: Bosque.
+          text: Un área del mapa delimitada por caminos y claros.
+        - name: Camino.
+          text: Una unión blanca entre dos claros.
+        - name: Colocar o poner.
+          text: Tomar la pieza indicada de la fuente indicada y situarla en el destino indicado. Normalmente, si no se especifica fuente, se toma de la reserva, o del espacio más a la izquierda del contador que contenga una pieza indicada.
+        - name: Descartar.
+          text: Coloca la carta indicada en la pila de descartes común (`rule:2.1`). Si es una carta de dominancia, se coloca cerca del tablero (`rule:3.3.3`). `faction:cult:10.4.2`
+        - name: Edificio.
+          text: Una pieza de cartón cuadrada propiedad de su facción _(cuenta para gobernar)_.
+        - name: Efecto.
+          text: Cualquier cosa que altere la partida, incluyendo efectos persistentes, habilidades de facción y acciones.
+        - name: Enemigo.
+          text: Cualquier otro jugador con el que no se esté en una coalición (`rule:9.2.8`), o un secuaz que esté en la reserva o controlado por un jugador enemigo.
+        - name: Espacio, del mapa.
+          text: Recuadro blanco en un claro (`rule:2.2.3`).
+        - name: Ficha.
+          text: Una pieza de cartón redonda propiedad de su facción _(no cuenta para gobernar)_.
+        - name: Forzar.
+          text: Ver `rule:1.5.5`.
+        - name: Gastar.
+          text: Ver **Descartar** (`rule:16.6.6`). _(Son términos equivalentes, pero_ **gastar** _se usa en contextos con elección.)_.
+        - name: Gobernar.
+          text: Ver `rule:2.5`.
+        - name: Guerrero.
+          text: Una figura de madera propiedad de su facción _(cuenta para gobernar. El peón del Vagabundo no es un guerrero y no puede ser retirado)_.
+        - name: Habilidad.
+          text: Un efecto persistente de una facción indicado en la parte superior de su tablero de facción y en su sección de Reglas y Habilidades de Facción, o un efecto persistente de un secuaz indicado en su carta de secuaz (`rule:16.4.2`).
+        - name: Intercambiar.
+          text: Cambia la localización de las dos piezas indicadas. _(Esto ignora las restricciones a_ **mover** _y_ **colocar**_, como el cepo de los Córvidos o la fortaleza del Marquesado)_.
+        - name: Mapa o tablero.
+          text: Ver `rule:2.2`.
+        - name: Mostrar.
+          text: Dejar al jugador indicado ver la pieza indicada.
+        - name: No puedes, no se puede.
+          text: Ver `rule:1.1.2`.
+        - name: Objeto.
+          text: Una pieza de cartón cuadrada que muestra un objeto (`item:boot`, `item:sword`, `item:crossbow`, etc.) que no es propiedad de ninguna facción.
+        - name: Peón.
+          text: Una figura de madera propiedad de su facción.
+        - name: Pieza.
+          text: "Cualquier componente: edificio, ficha, guerrero, peón, objeto, marcador, etc."
+        - name: Pieza de Facción.
+          text: Todos los guerreros, peones, edificios y fichas listados en la parte trasera de un tablero de facción. _(Los objetos no son piezas de facción.)_ Ver `rule:1.5.2`.
+        - name: Pieza enemiga.
+          text: La pieza de facción de un jugador enemigo o la pieza de secuaz de un secuaz enemigo, salvo que se estén tratando a esas piezas como propias para gobernar _(mercenarios de la Compañía, secuaces controlados, etc.)_. _(Los objetos no pueden ser piezas enemigas.)_
+        - name: Reemplazar.
+          text: Forma breve para **retirar** y luego **colocar**. Retira la pieza indicada y coloca la otra pieza indicada en la localización que ocupaba la que fue previamente retirada. Debes completar todos los pasos del **reemplazo** para poder realizarlo.
+        - name: Reserva.
+          text: El conjunto de piezas que no están en el tablero de una facción o en el mapa. La reserva de objetos es el expositor de objetos en el tablero.
+        - name: Retirar.
+          text: Tomar la pieza indicada de la fuente indicada y devolverla al destino indicado. Normalmente, si no se especifica destino, se devuelve a la reserva de su dueño, al espacio más a la derecha vacío de su contador o se retira permanentemente. _(Los objetos se retiran permanentemente, se devuelven a la caja)_.
+        - name: Revelar.
+          text: Coloca la carta indicada bocarriba en tu zona de juego. Normalmente, si no se especifica fuente, desde tu mano.
+        - name: Río.
+          text: Una unión azul entre dos claros.
+          name: Robar.
+          text: Toma la carta superior del mazo común (`rule:2.1`).
+        - name: Ruina.
+          text: Pieza que cubre un espacio "R" en un claro (`rule:2.2.4`).
+        - name: Tratar.
+          text: La cosa indicada adquiere las propiedades de la segunda cosa indicada. Mientras tratas piezas enemigas como propias para gobernar, no son piezas enemigas, pero siguen siendo piezas de la facción de ese jugador enemigo. _(Por ejemplo, los guerreros de la Compañía controlados como mercenarios no son piezas enemigas, pero todavía son piezas de la facción de la Compañía)_.
+        - name: Zona de juego.
+          text: La zona alrededor de tu tablero de facción. Las cartas en ella solamente se pueden gastar, descartar o usar para otros propósitos si se indica expresamente.

--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -78,7 +78,7 @@
           text: Los espacios marcados con una "R" empiezan el juego ocupados con **ruinas**. Las ruinas no pueden retirarse a menos que se indique expresamente _(como por la acción de Explorar del Vagabundo, `rule:9.5.3`)_.
     
     - name: Ríos
-      pretext: Muchos claros están unidos por **ríos**. _(Los ríos no son caminos, pero pueden traterse como caminos si se indica expresamente. Los ríos no dividen claros ni a los bosques)_ `faction:riverfolk:11.2.2`
+      pretext: Muchos claros están unidos por **ríos**. _(Los ríos no son caminos, pero pueden tratarse como caminos si se indica expresamente. Los ríos no dividen claros ni a los bosques)_ `faction:riverfolk:11.2.2`
       
     - name: Bosques
       pretext: Las áreas del mapa delimitadas por caminos impresos y claros se llaman **bosques**.
@@ -124,44 +124,49 @@
   color: "#000000"
   children:
     - name: Fabricar
-      pretext: Puedes **fabricar** la mayoría de cartas de tu mano para obtener un efecto inmediato o persistente.
+      pretext: Puedes **fabricar** la mayor parte de cartas de tu mano para obtener un efecto inmediato o persistente.
       children:
         - name: Coste.
-          text: Para fabricar una carta, debes **activar** piezas de fabricación del palo indicado en el icono de la esquina inferior izquierda de la carta. El palo de una pieza de fabricación corresponde al claro donde esté situada _(algunas facciones pueden tener mecánicas específicas para sus piezas)_. Cada pieza de fabricación puede ser activada una sola vez por turno. Un icono de fabricación tricolor con un signo de interrogación indica que se puede utilizar una pieza de fabricación de cualquier palo. `faction:vagabond:9.2.1` `faction:riverfolk:11.2.1`
-        - name: Efectos inmediatos.
-          text: Al fabricar una carta con un efecto inmediato, resuelve su efecto y luego descarta la carta. Si el efecto indica un objeto, toma dicho objeto de la reserva general del tablero y colócalo en tu zona de objetos fabricados de tu tablero de facción. Si la carta indica un objeto que ya no está disponible en la reserva, la carta no puede ser fabricada. `faction:eyrie:7.8.1` `faction:vagabond:9.5.8`
-        - name: Efectos persistentes.
-          text: Al fabricar una carta con un efecto persistente, colócala en tu área de juego. A partir de ahora, puedes hacer uso del efecto descrito en la carta.
-        - name: Sin duplicados.
-          text: No puedes fabricar un efecto persistente si ya tienes dicho efecto en tu área de juego. 
+          text: Para fabricar una carta, debes **activar** las piezas de fabricación de los palos que aparecen en la esquina inferior izquierda de la carta. Las piezas de fabricación de cada facción se indican en su sección de Fabricar. El palo de una pieza de fabricación se corresponde con su claro. Cada pieza de fabricación puede activarse una única vez por turno. Una interrogación tricolor denota una pieza de fabricación de cualquier palo. `faction:vagabond:9.2.1` `faction:riverfolk:11.2.1` `faction:cult:10.2.1`
+        - name: Efectos Inmediatos.
+          text: Cuando fabriques un efecto inmediato _(recuadro de pergamino)_, resuelve el efecto y después descarta la carta. Si muestra un objeto, toma el objeto correspondiente de la reserva común de objetos del mapa y colócalo en la zona de objetos fabricados de tu tablero de facción. Si la carta muestra un objeto que no está en la reserva, la carta no puede fabricarse. `faction:eyrie:7.8.1` `faction:vagabond:9.5.8` `faction:warlord:14.2.1`
+        - name: Efectos Persistentes.
+          text: Cuando fabriques un efecto persistente _(recuadro de piedra)_, colócalo en tu zona de juego. Puedes usar el efecto tal y como se describe en la carta. _(el Emigrante del Nido en el mazo de Exiliados y Partisanos es obligatorio)_.
+        - name: Sin Duplicados.
+          text: No puedes fabricar un efecto persistente si tienes uno idéntico en tu zona de juego. 
   
     - name: Mover
-      pretext: Al **mover** debes trasladar cualquier cantidad de guerreros _(siempre más que 0)_ o tu peón de un claro a otro claro adyacente.
+      pretext: Cuando **mueves**, puedes tomar cualquier número _(superior a cero)_ de tus guerreros o peones de un claro y moverlos a otro claro adyacente.
       children:
-        - name: Debes gobernar.
-          text: Para realizar un movimiento, debes gobernar el claro de origen, el claro de destino o ambos. `faction:vagabond:9.2.3` `faction:riverfolk:11.2.2` `faction:corvid:13.2.3`
-        - name: Movimiento no limitado.
-          text: Una misma pieza puede moverse varias veces en el mismo turno. Si se te indica que muevas varias veces, puedes mover el mismo guerrero o mismo grupo de guerreros varias veces si lo deseas _(incluso realizar el mismo movimiento a la inversa)_.
+        - name: Debes Gobernar.
+          text: Para poder mover, debes gobernar el claro de origen, el de destino, o ambos. `faction:vagabond:9.2.3` `faction:riverfolk:11.2.2` `faction:corvid:13.2.3`
+        - name: Sin Límites.
+          text: Una pieza cualquiera puede moverse cualquier número de veces por turno. Si se te pide que hagas varios movimientos, puedes mover el mismo o distintos grupos de guerreros.
 
     - name: Batallar
-      pretext: Al **batallar**, elige un claro en el que tengas guerreros o tu peón; este será el **claro de la batalla**. Tú serás el **atacante**. Elige a otra facción presente en dicho claro para que sea el **defensor**; la batalla será entre vosotros dos.
+      pretext: Cuando **batallas**, elige un claro donde tengas cualquier número de guerreros y peones como el **claro de batalla**. Tú eres el **atacante**. Elige a un enemigo en el claro de batalla que será el **defensor** _(hay al menos una de sus piezas ahí)_.
       children:
-        - name: "Paso 1: el Defensor puede emboscar."
-          text: El defensor puede jugar una sola carta de emboscada del palo correspondiente al del claro de la batalla. Si la emboscada no es truncada, el defensor inflige dos impactos de forma inmediata, y después descarta dicha carta de emboscada. En caso de que el atacante se quede sin guerreros o peones, la batalla termina inmediatamente.
+        - name: "Paso 1: El Defensor Puede Emboscar."
+          text: El defensor puede jugar una (y solo una) carta de emboscada correspondiente al claro de la batalla. De ser así resuelve `rule:4.3.1.1`–`rule:4.3.1.2` en order.
           subchildren:
-            - name: Truncar emboscada.
-              text: Después de que el defensor juegue una carta de emboscada, el atacante puede responder jugando también una carta de emboscada del palo correspondiente al del claro de la batalla para cancelar su emboscada. _(El defensor debe descartar igualmente su carta de emboscada)_
-        - name: "Paso 2: Lanzar dados y sumar impactos adicionales."
-          text: Lanza ambos dados. El atacante puede causar tantos impactos como marque el valor más alto, y el defensor puede causar tantos impactos como marque el valor más bajo. Si ambos dados marcan el mismo resultado, tanto atacante como defensor pueden infligir los mismos impactos `faction:woodland:8.2.2`. _(Decimos "pueden" porque los impactos no se aplican hasta el paso 3.)_ 
+            - name: Emboscada Truncada.
+              text: El atacante puede jugar también una carta de emboscada correspondiente al claro de batalla. De ser así, ambos jugadores descartan sus cartas de emboscada sin aplicar sus efectos y se omite el paso `rule:4.3.1.2`.
+            - name: Resuelve la Emboscada.
+              text: El defensor da inmediatamente dos golpes al atacante (`rule:4.3.4`). Después, el defensor descarta la carta de emboscada. Si no quedan guerreros o peones atacantes, la batalla finaliza inmediatamente.
+        - name: "Paso 2: Tirar Dados"
+          text: Tira ambos dados. El atacante golpeará tantas veces como la tirada más alta, y el defensor golpeará tantas veces como la tirada más baja. Si las tiradas son iguales, el atacante y el defensor golpearán el mismo número de veces _(el uso del futuro aquí refleja que los golpes no se aplican hasta el paso 4)_. `faction:woodland:8.2.2`
           subchildren:
-            - name: Impactos máximos por dado.
-              text: El número de impactos máximos por tirada de dados que un jugador infligir está limitado por el número de guerreros presentes en el claro de la batalla, tanto si eres el atacante como el defensor. `faction:vagabond:9.2.6`
-            - name: Impactos adicionales.
-              text: Después de obtener el resultado del dado, tanto atacante como defensor pueden añadir **impactos adicionales** por medio de habilidades especiales u otros efectos que tengan en su área de juego. _(Los impactos adicionales no están limitados por el número de guerreros en el claro de la batalla.)_
+            - name: Golpes Máximos por Tirada.
+              text: El número máximo de golpes que puedes causar debido a tu tirada es igual al número de tus guerreros en el claro de batalla, ya seas el atacante o el defensor. `faction:vagabond:9.2.6`
+        - name: "Paso 3: Usar Efectos"
+          text: El atacante y el defensor pueden usar efectos opcionales _(como la carta Tácticas Brutales)_ que afecten a la batalla. Si ambos quieren hacerlo, el atacante escoge quién los usa primero (`rule:1.1.3`).
+          subchildren:
+            - name: Golpes Adicionales.
+              text: Muchos efectos causarán **golpes adicionales**, estos golpes no están limitados por el número de guerreros en el claro de batalla.
             - name: Indefenso.
-              text: Si el defensor no tiene guerreros en el claro de la batalla, el atacante infligirá un impacto adicional. `faction:vagabond:9.2.4`
-        - name: "Paso 3: Infligir impactos."
-          text: "El atacante y el defensor se infligen impactos simultáneamente. Cada impacto causado obliga a retirar una pieza. El jugador que recibe impactos debe elegir qué piezas retira del claro de la batalla, pero está obligado a retirar siempre primero todos sus guerreros antes que retirar edificios o fichas; en dicho caso, el jugador elegirá en qué orden retira estas piezas. _(Recuerda: obtienes 1 punto de victoria por edificio o ficha enemiga que retires.)_"
+              text: Si el defensor no tiene guerreros en el claro de la batalla, el atacante da un golpe adicional. `faction:vagabond:9.2.4`
+        - name: "Paso 4: Recibir Golpes."
+          text: "Cada golpe que da un bando retira una pieza del otro bando en el claro de batalla _(obtienes un punto de victoria por cada edificio o ficha enemiga que retires)_. El bando que recibe un golpe decide en qué orden se retiran sus piezas, aunque todos sus guerreros han de ser retirados antes de que sus edificios o fichas puedan retirarse; también escogen el orden de cualquier efecto que provoque la retirada de sus piezas."
 
 - name: Preparación
   color: "#000000"

--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -43,7 +43,7 @@
         - name: Pertenencia de las piezas.
           text: El propietario de las piezas de una facción no puede cambiar. _(Por ejemplo, el Marquesado no puede usar sus hospitales de Campaña con los secuaces o los mercenarios de la Compañía, ya que no son guerreros del Marquesado)_.
         - name: Manejo de las piezas.
-          text: Las piezas se colocan y retiran como se indica en el Glosario (`rule:16.6.5`, `rule:16.6.28`). Si se te indica que coloques, tomes o retires piezas pero no puedes hacerlo al completo, debes colocar, tomar o retirar las máximas posibles. _(Esto no te permite evitar costes o requisitos. No puedes hacer menos de lo máximo que puedes hacer)_.
+          text: Las piezas se colocan y retiran como se indica en el Glosario (`rule:16.6.5`, `rule:16.6.28`). Si se te indica que coloques, tomes o retires piezas pero no puedes hacerlo al completo, debes colocar, tomar o retirar las máximas posibles. _(Esto no te permite evitar costes o requisitos. No puedes hacer menos de lo máximo que puedes hacer)_. Si se remueven múltiples piezas de manera simultánea y eso provoca efectos, retira todas las piezas antes de provocar los efectos.
         - name: Uso de **Forzar**.
           plainName: Uso de Forzar.
           text: Algunos efectos te permiten **forzar** a un jugador o a sus piezas a actuar. Resuelve la situación del mismo modo en el que ese jugador lo haría _(siguiendo las reglas generales)_, teniendo en cuenta posibles efectos. _(Por ejemplo, si fuerzas al Nido a mover guerreros, se benefician de la regla Señores del Bosque)_.
@@ -460,11 +460,9 @@
           text: Las capacidades del Vagabundo dependen de los objetos que tenga. En lugar de una zona para Objetos Fabricados tiene un Hatillo y varios contadores. Los objetos en el tablero de facción del Vagabundo pueden estar bocarriba o bocabajo. El Vagabundo **agota** objetos no dañados, volteándolos bocabajo, para hacer muchas de sus acciones.
           subchildren:
             - name: Contadores.
-              text: Al obtenerlos o al voltearlos bocarriba, coloca `item:tea`, `item:coin`, y `item:sack` bocarriba en sus contadores. Cada contador puede tener hasta 3 objetos del mismo tipo.
+              text: Al obtenerlos o al voltearlos bocarriba en el hatillo, coloca `item:tea`, `item:coin`, y `item:sack` bocarriba en sus contadores. Cuando voltees bocabajo `item:tea`, `item:coin`, o `item:sack` en su contador, colócalo bocabajo en tu hatillo. Cada contador puede tener hasta 3 objetos del mismo tipo.
             - name: El Hatillo.
               text: Al obtenerlos, coloca `item:boot`, `item:sword`, `item:crossbow`, `item:torch`, y `item:hammer` bocarriba en el hatillo.
-            - name: Mover Objetos.
-              text: El Vagabundo puede mover libremente `item:tea`, `item:coin`, y `item:sack` entre sus contadores y el hatillo, siempre y cuando estén bocarriba y no dañados.
         - name: Golpes Máximos por Tirada.
           text: En batalla, sus golpes máximos por tirada (`rule:4.3.2.1`) son iguales a sus `item:sword` no dañadas, bocarriba o bocabajo, en su hatillo.
         - name: Recibir Golpes.
@@ -543,7 +541,7 @@
         - name: Golpear.
           text: Agota una `item:crossbow` para retirar a un guerrero enemigo de tu claro. Si ese enemigo no tiene guerreros en ese claro puedes retirar una de sus otras piezas de facción allí en su lugar _(comprueba tu relación con la facción de ese jugador)_.
         - name: Reparar.
-          text: Agota un `item:hammer` para mover un objeto dañado a tu hatillo _(si es `item:boot`, `item:hammer`, `item:sword`, `item:crossbow` o `item:torch`)_ o a su contador desde tu hatillo _(si es `item:coin`, `item:tea`, `item:sack` si está bocarriba)_. En cualquier caso, no le des la vuelta al objeto.
+          text: Agota un `item:hammer` para mover un objeto dañado a tu hatillo _(si es `item:boot`, `item:hammer`, `item:sword`, `item:crossbow` o `item:torch`)_ o inmediatamente a su contador desde tu hatillo _(si es `item:coin`, `item:tea`, `item:sack` si está bocarriba)_. En cualquier caso, no le des la vuelta al objeto.
         - name: Fabricar.
           text: Juega una carta de tu mano y agota el correspondiente `item:hammer` para fabricarla. Todos tus `item:hammer` se corresponden con tu claro. Si una carta requiere más de una activación de un mismo palo para poder ser fabricada, debes agotar el número requerido de `item:hammer`. Si fabricas un objeto, puedes colocarlo bocarriba en tu hatillo o en su contador.
         - name: Acción Especial.
@@ -760,7 +758,7 @@
         - name: La Madriguera.
           text: La **madriguera** es un claro sin palo adyacente a cada claro que tiene una ficha de túnel. Ninguna pieza que no sea del Ducado se puede colocar o mover en la madriguera. El Ducado siempre gobierna la madriguera _(incluso si no tiene piezas allí)_.
         - name: El Precio del Fracaso.
-          text: Siempre que se retiren cualquier número de edificios del Ducado, el Ducado descarta una carta al azar, devuelve su carta de ministro convencido de mayor rango _(primero lord, después noble, después escudero)_ a la pila de ministros sin convencer, y guarda su corona en la caja. Si tiene varios ministros convencidos del rango más alto, el Ducado elige cuál retira.
+          text: Siempre que se retiren cualquier número de edificios del Ducado, el Ducado devuelve su carta de ministro convencido de mayor rango _(primero lord, después noble, después escudero)_ a la pila de ministros sin convencer, guarda su corona en la caja, y luego descarta una carta al azar. Si tiene varios ministros convencidos del rango más alto, el Ducado elige cuál retira.
         - name: Túneles.
           text: El Ducado tiene tres fichas de túnel. Si se le indica al Ducado que coloque un túnel y ya están los tres túneles sobre el mapa, el ducado puede retirar primero un túnel cualquiera del mapa.
 

--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -1273,3 +1273,12 @@
               text: El controlador de un secuaz no obtiene puntos de victoria si sus secuaces retiran una pieza enemiga _(normalmente en batalla)_. _(Sin embargo, los jugadores sí pueden obtener puntos al retirar edificios y fichas pertenecientes a secuaces, incluso al ser el defensor contra un secuaz. Un jugador obtiene puntos de forma habitual si los Profetas del Cálido Sol fuerzan a las piezas de su facción a batallar)_.
             - name: Cosas Raras.
               text: Si mueves a un secuaz con el Transbordador, robas una carta. Si mueves a un guerrero secuaz a un claro con una ficha de simpatía de la Alianza o retiras una ficha de simpatía usando a un secuaz, se activa Indignación. _(Estos efectos se refieren al "jugador que mueve" o "al jugador que retira")_.
+
+    - name: Lugares Míticos
+      children:
+        - name: Reglas Generales
+          subchildren:
+            - name: Seguridad.
+              text: Los lugares míticos no pueden ser movidos o retirados, ni se puede batallar contra ellos, a menos que se indique expresamente en el lugar mítico.
+            - name: Pertenencia.
+              text: Los lugares míticos no son propiedad de ninguna facción y no son piezas enemigas.

--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -1181,77 +1181,59 @@
             - name: Bosques.
               text: Todas las áreas del mapa de montaña delimitadas por caminos y claros son bosques (`rule:2.2`), independientemente de que haya árboles impresos o no.
 
-    - name: Vagabundos
+    - name: Guía del Vagabundo
       children:
         - name: Ladrón
           subchildren:
-            - name: Objetos iniciales ("S")
-              text: Comienza la partida con `item:boot`, `item:torch`, `item:tea`, `item:sword`.
-
-            - name: "Acción especial: Robar"
-              text: Agota una `item:torch` para robarle una carta de la mano al azar a cualquier otro jugador presente en tu claro.
-
+            - name: Objetos Iniciales.
+              text: Empieza con `item:boot`, `item:torch`, `item:tea`, `item:sword`.
+            - name: "Acción Especial: Robar"
+              text: Agota una `item:torch` para robar una carta al azar de un jugador cualquiera en tu claro.
         - name: Chatarrero
           subchildren:
-            - name: Objetos iniciales ("S")
-              text: Comienza la partida con `item:boot`, `item:torch`, `item:sack`, `item:hammer`.
-
-            - name: "Acción especial: Tareas diurnas"
-              text: Agota una `item:torch` para coger una carta del palo correspondiente a tu claro de la pila de descarte. _(You can always take a bird card.)_
-
+            - name: Objetos Iniciales
+              text: Empieza con `item:boot`, `item:torch`, `item:sack`, `item:hammer`.
+            - name: "Acción Especial: Trabajo Diurno"
+              text: Agota una `item:torch` para tomar una carta de la pila de descartes del palo correspondiente a tu claro. _(Siempre puedes tomar una carta de ave)_.
         - name: Montaraz
           subchildren:
-            - name: Objetos iniciales ("S")
-              text: Comienza la partida con `item:boot`, `item:torch`, `item:crossbow`, `item:sword`.
-
-            - name: "Acción especial: Esconderse"
-              text: Agota un `item:torch` para reparar 3 objetos. Después, termina tu Día inmediatamente y comienza tu Noche.
-
+            - name: Objetos Iniciales
+              text: Empieza con `item:boot`, `item:torch`, `item:crossbow`, `item:sword`.
+            - name: "Acción Especial: Escondite"
+              text: Agota un `item:torch` para reparar tres objetos. Entonces termina tu Día inmediatamente y empieza tu Noche.
         - name: Agitador
           subchildren:
-            - name: Objetos iniciales ("S")
-              text: Comienza la partida con `item:coin`, `item:torch`, `item:boot`.
-
-            - name: "Acción especial: Instigar"
-              text: Agota una `item:torch` para provocar una batalla en tu claro. Tú eliges tanto al atacante como al defensor, el orden de retirada de fichas y edificios, y retiras piezas por ambos. _(Obtienes 1 punto de victoria por ficha o edificio retirado, independientemente del propietario, y también por cada pieza Hostil que retires)_
-
+            - name: Objetos Iniciales
+              text: Empieza con `item:coin`, `item:torch`, `item:boot`.
+            - name: "Acción Especial: Instigar"
+              text: Agota una `item:torch` para iniciar una batalla en tu claro. Tú escoges tanto al atacante como al defensor y el orden en que se retiran edificios y fichas, y retiras las piezas para ambos. _(Obtén un punto de victoria por cada edificio o ficha de cualquiera de los jugadores que sea retirada, yu por cada pieza hostil que se retire de cualquier jugador)_.
         - name: Árbitro
           subchildren:
-            - name: Objetos iniciales ("S")
-              text: Comienza la partida con `item:boot`, `item:torch`, `item:sword`, `item:sword`.
-
-            - name: "Habilidad especial: Proteger"
-              text: Antes de tirar los dados en batalla, el defensor puede pedir ayuda al Árbitro si está en el claro de la batalla. Si lo hace, el Árbitro obtiene 1 punto de victoria y añade sus `item:sword` no dañadas a los impactos máximos por dado del defensor.  Esta habilidad no se aplica a ti mismo.
-
+            - name: Objetos Iniciales
+              text: Empieza con `item:boot`, `item:torch`, `item:sword`, `item:sword`.
+            - name: "Acción Especial: Proteger"
+              text: Inmediatamente antes de que se tiren los dados en una batalla, el defensor puede pedir ayuda al Árbitro si está en el claro de batalla. El Árbitro obtiene un punto de victoria y añade todas sus `item:sword` no dañadas a los golpes máximos que obtenga el defensor en la tirada de dados. El Árbitro no puede apuntarse por voluntad propia o en contra de su voluntad.
         - name: Bribón
           subchildren:
-            - name: Objetos iniciales ("S")
-              text: Comienza la partida con `item:boot`, `item:boot`, `item:torch`, `item:crossbow`.
-
-            - name: "Acción especial: Tierra quemada"
-              text: Agota una `item:torch` y colócala en tu claro. Retira todas las piezas enemigas de dicho claro. Durante el resto de la partida, nadie podrá colocar piezas o mover a este claro. _(Tú permaneces en el claro, pero una vez salgas de él, no podrás volver a entrar)_
-
+            - name: Objetos Iniciales
+              text: Empieza con `item:boot`, `item:boot`, `item:torch`, `item:crossbow`.
+            - name: "Acción Especial: Tierra Quemada"
+              text: Agota una `item:torch` y colócala en tu claro. Retira todas las piezas enemigas de ese claro. Durante el resto de la partida, las piezas no pueden colocarse o moverse a este claro. _(Tú permaneces en el claro. Una vez que salgas, no puedes volver a entrar. La `item:torch` no puede retirarse con una carta de "Favor de los..." porque no es una pieza enemiga)_.
         - name: Aventurero
           subchildren:
-            - name: Objetos iniciales ("S")
-              text: Comienza la partida con `item:boot`, `item:torch`, `item:hammer`.
-
-            - name: "Acción especial: Improvisar"
-              text: Una vez por turno, al realizar la acción de Misión, puedes tratar uno de tus objetos no agotados como si fuese cualquier otro objeto para completar la misión. Si lo haces, daña dicho objeto. 
-
+            - name: Objetos Iniciales
+              text: empieza con con `item:boot`, `item:torch`, `item:hammer`.
+            - name: "Acción Especial: Improvisar"
+              text: Una vez por turno durante una acción de Misión, puedes tratar un objeto no agotado como cualquier otro objeto. Cuando lo agotes para completar la misión, dáñalo también.
         - name: Ronin
           subchildren:
-            - name: Objetos iniciales ("S")
-              text: Comienza la partida con `item:boot`, `item:boot`, `item:torch`, `item:sword`.
-
-            - name: "Acción especial: Golpe de gracia"
-              text: Puedes agotar una `item:sword` para infligir 1 impacto adicional en batalla _(después de lanzar dados)_.
-
+            - name: Objetos Iniciales
+              text: Empieza con `item:boot`, `item:boot`, `item:torch`, `item:sword`.
+            - name: "Acción Especial: Golpe Rápido"
+              text: Puedes agotar una `item:sword` para dar un golpe adicional _(después de lanzar dados en batalla)_.
         - name: Hostigador
           subchildren:
-            - name: Objetos iniciales ("S")
-              text: Comienza la partida con `item:coin`, `item:torch`, `item:sword`, `item:crossbow`.
-
-            - name: "Acción especial: Infiltración en claro"
-              text: Agota una `item:torch` para mover a cualquier claro del mapa _(incluso un claro Hostil)_  sin agotar ninguna `item:boot`.
-    
+            - name: Objetos Iniciales
+              text: Empieza con `item:coin`, `item:torch`, `item:sword`, `item:crossbow`.
+            - name: "Acción Especial: Vuelo sin motor"
+              text: Agota una `item:torch` para mover únicamente a tu peón de Vagabundo _(no otras piezas)_ a cualquier claro _(incluso Hostil)_ del mapa sin agotar ninguna `item:boot`.

--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -413,7 +413,7 @@
       children:
         - name: Fabricar.
           text: Puedes activar fichas de simpatía para fabricar cartas de tu mano.
-        - name: Mobilizar.
+        - name: Movilizar.
           text: Añade una carta de tu mano al montón de simpatizantes.
         - name: Entrenar.
           text: Gasta una carta correspondiente al palo indicado por una base en el mapa para colocar un guerrero en la zona de oficiales. Este guerrero ahora es un **oficial**.
@@ -440,7 +440,7 @@
   icon: vagabond
   children:
     - name: Resumen
-      pretext: El Vagabundo puede apoyar a todos los bandos de este conflicto, al tiempo que lleva a cabo misiones para incrementar su reputación. Cada vez que mejoras tu **relación** con otra facción, o bien quitas un guerrero que pertence a una facción hostil, obtienes puntos de victoria. También puedes completar **misiones** para obtener puntos de victoria. Para mover y actuar de forma efectiva con el Vagabundo debes gestionar tu hatillo de **objetos**, expandiendo tu colección al explorar las ruinas en los claros y ayudar a otras facciones.
+      pretext: El Vagabundo puede apoyar a todos los bandos de este conflicto, al tiempo que lleva a cabo misiones para incrementar su reputación. Cada vez que mejoras tu **relación** con otra facción, o bien quitas un guerrero que pertenece a una facción hostil, obtienes puntos de victoria. También puedes completar **misiones** para obtener puntos de victoria. Para mover y actuar de forma efectiva con el Vagabundo debes gestionar tu hatillo de **objetos**, expandiendo tu colección al explorar las ruinas en los claros y ayudar a otras facciones.
     
     - name: Reglas y Habilidades de Facción
       children:
@@ -460,7 +460,7 @@
           text: Las capacidades del Vagabundo dependen de los objetos que tenga. En lugar de una zona para Objetos Fabricados tiene un Hatillo y varios contadores. Los objetos en el tablero de facción del Vagabundo pueden estar bocarriba o bocabajo. El Vagabundo **agota** objetos no dañados, volteándolos bocabajo, para hacer muchas de sus acciones.
           subchildren:
             - name: Contadores.
-              text: Al obtenerlos o al voltearlos bocarriba, coloca `item:tea`, `item:coin`, y `item:sack` bocarriba en sus contadores. Cada contador puede tner hasta 3 objetos del mismo tipo.
+              text: Al obtenerlos o al voltearlos bocarriba, coloca `item:tea`, `item:coin`, y `item:sack` bocarriba en sus contadores. Cada contador puede tener hasta 3 objetos del mismo tipo.
             - name: El Hatillo.
               text: Al obtenerlos, coloca `item:boot`, `item:sword`, `item:crossbow`, `item:torch`, y `item:hammer` bocarriba en el hatillo.
             - name: Mover Objetos.
@@ -509,7 +509,7 @@
         - name: "Paso 1: Elegir un Personaje."
           text: Elige una carta de personaje y colócala en tu espacio de carta de personaje.
         - name: "Paso 2: Colocar el Peón."
-          text: Coloca tu peón de Vagabundo en un bosquer a tu elección.
+          text: Coloca tu peón de Vagabundo en un bosque a tu elección.
         - name: "Paso 3: Conseguir Misiones."
           text: Baraja tu mazo de misiones, roba 3 cartas de misión y colócalas bocarriba junto a ti.
         - name: "Paso 4: Llenar las Ruinas."
@@ -559,7 +559,7 @@
         - name: Descartar Cartas.
           text: Si tienes más de cinco cartas en tu mano, descarta cartas a tu elección hasta quedarte con cinco.
         - name: Comprobar Capacidad.
-          text: Si tienes mṕas objetos en total en tu hatillo y tu zona de dañados que tu límite de objetos _(seis más dos por cada `item:sack` bocarriba en su contador)_ retira objetos de tu hatillo o zona de dañados hasta quedarte con un número de objetos igual a tu límite y devuélvelos a la caja.
+          text: Si tienes más objetos en total en tu hatillo y tu zona de dañados que tu límite de objetos _(seis más dos por cada `item:sack` bocarriba en su contador)_ retira objetos de tu hatillo o zona de dañados hasta quedarte con un número de objetos igual a tu límite y devuélvelos a la caja.
 
     - name: Jugar con Dos Vagabundos
       subtext: Si tienes la expansión _Los Ribereños_, puedes jugar una partida con dos Vagabundos siguiendo estas reglas.
@@ -576,7 +576,7 @@
   icon: cult
   children:
     - name: Resumen
-      pretext: El Culto Reptiliano trata de abrumar a sus enemigos a través de fuerza de volutand bruta, y para ello utiliza a las criaturas descartadas del Bosque. En los claros que bogierna el Culto puede construir **jardines**, con los que aumenta el boca a pico para difundir su evangelio. Cuanto mayor sea su control sobre el corazón de sus fieles, el Culto obtendrá más puntos de victoria al completar ciertos **rituales**. Mientras que las otras facciones gastan cartas para lograr sus objetivos, el Culto principalmente revela cartas y gradualmente las va seleccionando para conseguir el conjunto ideal de seguidores. A no ser que se usen para puntuar, esas cartas no se gastan y vuelve a la mano del Culto durante la Noche. Sin embargo, este enfoque más amable hace que el movimiento y las operaciones de combate sean más difíciles, así que esas acciones sólo pueden ser llevadas a cabo por sus **acólitos** más radicalizados, obtenidos a medida que los guerreros del Culto son masacrados al defender en batallas.
+      pretext: El Culto Reptiliano trata de abrumar a sus enemigos a través de fuerza de voluntad bruta, y para ello utiliza a las criaturas descartadas del Bosque. En los claros que gobierna el Culto puede construir **jardines**, con los que aumenta el boca a pico para difundir su evangelio. Cuanto mayor sea su control sobre el corazón de sus fieles, el Culto obtendrá más puntos de victoria al completar ciertos **rituales**. Mientras que las otras facciones gastan cartas para lograr sus objetivos, el Culto principalmente revela cartas y gradualmente las va seleccionando para conseguir el conjunto ideal de seguidores. A no ser que se usen para puntuar, esas cartas no se gastan y vuelve a la mano del Culto durante la Noche. Sin embargo, este enfoque más amable hace que el movimiento y las operaciones de combate sean más difíciles, así que esas acciones sólo pueden ser llevadas a cabo por sus **acólitos** más radicalizados, obtenidos a medida que los guerreros del Culto son masacrados al defender en batallas.
 
     - name: Reglas y Habilidades de Facción
       children:
@@ -622,7 +622,7 @@
               text: Gasta tres acólitos para reemplazar un edificio enemigo de un claro de paria por un jardín correspondiente.
 
     - name: Día
-      pretext: Puedes revelar cualquier número de cartas de tu mano y llevar a cabo un ritual por cada carta revelada, en cualquier orden y número, de la manera siguiente. _(Las cartas reveladas de tu mano se sitúan bocarriba en tu zona de juego y no se pueden suar para ningún otro propósito durante el Día)_.
+      pretext: Puedes revelar cualquier número de cartas de tu mano y llevar a cabo un ritual por cada carta revelada, en cualquier orden y número, de la manera siguiente. _(Las cartas reveladas de tu mano se sitúan bocarriba en tu zona de juego y no se pueden usar para ningún otro propósito durante el Día)_.
       children:
         - name: Construir.
           text: Coloca un jardín correspondiente a la carta revelada en un claro que gobiernes, también correspondiente a la carta revelada.
@@ -648,103 +648,103 @@
   icon: riverfolk
   children:
     - name: Resumen
-      pretext: Cuando a la comunidad del Bosque llegó la noticia que las orillas del gran lago se estaban convirtiendo en el escenario de una guerra total, la Compañía del Río no tardó en mandar a sus oficiales a hacer negocios. Mientras otras facciones compran sus servicios, la Compañía del Río podrá reforzar sus intereses comerciales estableciendo **puestos comerciales** por el bosque, y sumar así puntos de victoria. Construir estos puestos comerciales es una manera de conseguir puntos, aunque también podrá obtenerlos acumulando **fondos**. No obstante, una gran fortuna también es un gran blanco, así que la Compañía del Río deberá ser cautelosa y mantener un equilibrio entre proteger su creciente fortuna y expandir sus operaciones a lo largo del peligroso bosque.
+      pretext: Cuando llegaron noticias de que se estaba desatando una guerra total en el Bosque, la Compañía del Río envió rápidamente a sus oficiales para ponerse manos a la obra. Mientras las otras facciones compran sus servicios, la Compañía podrá reforzar sus intereses comerciales construyendo **puestos comerciales** a lo largo del río, obteniendo puntos de victoria. También puede obtenerlos mediante la acumulación de **fondos**. Sin embargo, una tesorería boyante también se convierte en un objetivo fácil, así que la Compañía debe ser cuidadosa al expandir sus operaciones por el peligroso bosque.
 
     - name: Reglas y Habilidades de Facción
       children:
         - name: Fabricar.
-          text: La Compañía del Río fabrica durante el Día consignando fondos a los espacios vacíos de los contadores de Puestos Comerciales. _(La Compañía no tiene piezas de fabricación)_
+          text: La Compañía fabrica durante el Día consignando fondos a los espacios vacíos de los contadores de puestos comerciales _(no tiene piezas de fabricación)_.
         - name: Nadadores.
-          text: La Compañía del Río trata los ríos como caminos y puede moverse a través de ellos independientemente de quién gobierne el claro de origen o de destino. _(También puede moverse de forma normal a través de los caminos.)_
-        - name: Mano pública.
-          text:  La Compañía del Río coloca su mano de cartas a la vista de todos sobre su tablero de facción _(utiliza el sujetacartas incluido para este propósito)_. Si algún jugador tuviese que coger una carta al azar de la mano del jugador que controla la Compañía, dichas cartas deben ponerse bocabajo y barajarse para que dicho jugador elija una aleatoriamente. Después, recoloca las cartas mano a la vista de todos nuevamente.
+          text: La Compañía trata a los ríos como caminos y se puede mover por los ríos sin importar quien gobierne los claros de origen y destino _(también puede usa los caminos para moverse)_.
+        - name: En Venta.
+          text: La Compañía coloca su mano bocarriba sobre su tablero. Si otro jugador tuviera que robar una carta al azar de la mano de la Compañía, las cartas se ponen bocabajo, se mezclan y se roba la cantidad re querida. Luego, se vuelven a poner bocarriba.
         - name: Fondos.
-          text:  "Para realizar acciones, la Compañía del Río debe consignar y gastar **fondos**: guerreros en su casilla para Fondos."
+          text: "Para realizar sus acciones, la Compañía consigna y gasta **fondos**: Guerreros en su zona para fondos."
         - name: Puestos Comerciales.
-          text: La Compañía del Río suma puntos de victoria al colocar puestos comerciales en el mapa.
+          text: La Compañía obtiene puntos de victoria cuando construye puestos comerciales.
           subchildren:
-            - name: Interrupción al comercio.
-              text: Cuando un puesto comercial es retirado, la Compañía debe retirar la mitad de sus fondos (redondeando hacia arriba) y retirar dicho puesto comercial del juego de forma permanente, devolviéndolo a la caja.
-        - name: Compra de Servicios.
-          text: Al inicio de su Alba, cualquier otro jugador que no seas tú puede comprar los servicios de la Compañía del Río.
+            - name: Interrupción del Comercio.
+              text: Cuando un puesto comercial es retirado, la Compañía retira la mitad de sus fondos, redondeando hacia arriba, y devuelve ese puesto comercial a la caja.
+        - name: Comprar Servicios.
+          text: Al inicio de sus respectivas Albas, los otros jugadores pueden comprar los servicios de la Compañía.
           subchildren:
             - name: Coste.
-              text: El comprador debe colocar guerreros de su reserva personal en la zona de Pagos, tantos como corresponda al coste de dicho servicio según indique el contador de Servicios correspondiente de la Compañía.
-            - name: Cantidad de Servicios.
-              text: En cada turno, un jugador solo puede adquirir un servicio, más uno extra por cada claro en el que haya un puesto comercial y dicho jugador tenga al menos una pieza.
+              text: El comprador debe colocar tantos de sus guerreros en la zona de pagos de la Compañía como el coste del servicio, indicado en el contador correspondiente de la zona de servicios.
+            - name: Número.
+              text: Cada turno, un jugador puede comprar un servicio más uno adicional por cada claro con un puesto comercial en el que tenga al menos una pieza de su facción.
             - name: Fondos del Vagabundo.
-              text: El Vagabundo paga por los servicios agotando objetos. Por cada objeto que el vagabundo agote, la Compañía del Río coloca uno de sus propios guerreros de su reserva en la zona de Pagos.
-        - name: Servicios de la Compañía del Río.
-          text: La Compañía del Río ofrece tres servicios, detallados a continuación.
+              text: "El Vagabundo paga por los servicios agotando objetos: Por cada objeto que agote con ese fin, la Compañía coloca un guerrero de la Compañía en la zona de pagos."
+        - name: Servicios.
+          text: La Compañía ofrece tres tipos de servicios.
           subchildren:
-            - name: Carta de mano.
-              text: El comprador adquiere una carta de la mano de la Compañía del Río y la añade a su mano. _(Un jugador puede comprar este servicio más de una vez, siempre que tenga acceso a suficientes puestos comerciales)_
-            - name: Barcazas.
-              text: El comprador trata los ríos como caminos hasta el final de su turno.
+            - name: Carta de la Mano.
+              text: El comprador toma cualquier carta de la mano de la Compañía y la añade a la suya _(este servicio se puede comprar varias veces siempre que se tenga acceso a suficientes puestos comerciales)_.
+            - name: Barcas.
+              text: El comprador puede tratar los ríos como si fueran caminos hasta el final de su turno.
             - name: Mercenarios.
-              text:  Durante el Día y la Noche de su turno, el comprador trata a los guerreros de la Compañía del Río como si fuesen suyos a efectos de gobernar y para batallar contra otras facciones que no sean la Compañía. (El comprador de este servicio no puede mover los guerreros, computarlos a efectos de Dominancia ni retirarlos, salvo en el caso de que reciban impactos en batalla)_
+              text:  Durante el Día y la Noche de este turno, el comprador trata a los guerreros de la Compañía como si fueran suyos para de gobernar y para batallar contra cualquier facción que no sea la Compañía. _(El comprador no puede moverlos, usarlos para cumplir cartas de dominancia o retirarlos, a no ser que sea mediante golpes en batalla. Todavía son piezas de la Compañía, por lo que no se ven afectados por habilidades como Hospitales de Campaña del MArquesado ni pueden usarse para Convencer a Ministros del Ducado)_.
               subchildren:
-                - name: Recibir impactos.
-                  text: El comprador debe repartir los impactos recibidos en batalla de forma equitativa entre sus propias piezas y los guerreros de la Compañía, si los tiene, o entre sus propios edificios y/o fichas solo en caso de no tener guerreros _(contando con los mercenarios de la Compañía)_ en el claro de la batalla.
-                - name: Mercenarios y el Vagabundo.
-                  text: El Vagabundo no puede comprar el servicio de Mercenarios de la Compañía del Río.
+                - name: Golpes Recibidos.
+                  text: El comprador debe repartir los impactos, sufriendo los golpes impares retirando guerreros de su propiedad _(no de la Compañía)_, si quedan, o edificios de su propiedad o fichas sólo si no tiene guerreros _(incluyendo de la Compañía)_ en el claro de batalla.
+                - name: El Vagabundo y los Mercenarios.
+                  text: El Vagabundo no puede comprar mercenarios de la Compañía _(Si el comprador ataca al Vagabundo y se retira un mercenario de la Compañía, la facción del comprador se convierte en Hostil, no La Compañía)_.
 
-    - name: Preparación Individual
+    - name: Preparación
       children:
-        - name: "Paso 1: Guerreros."
-          text: Forma una reserva de 15 guerreros.
-        - name: "Paso 2: Colocar Guerreros."
-          text: Coloca 4 Guerreros en cualquiera de los claros en contacto con el río, repartiéndolos como desees.
-        - name: "Paso 3: Contadores de Puestos Comerciales."
-          text: Coloca los 9 puestos comerciales sobre sus respectivas casillas en los contadores correspondientes de tu tablero.
-        - name: "Paso 4: Fondos iniciales."
-          text: Coloca 3 guerreros en zona de Pagos.
-        - name: "Paso 5: Precios iniciales."
-          text: Coloca 1 marcador de servicios sobre cualquier casilla de su respectivo contador.
+        - name: "Paso 1: Juntar Guerreros."
+          text: Forma la reserva de guerreros (15).
+        - name: "Paso 2: Desembarcar."
+          text: Coloca 4 guerreros en cualquier claro o claros conectado(s) al río.
+        - name: "Paso 3: Rellenar los Contadores de Puesto Comercial."
+          text: Coloca 9 puestos comerciales en los espacios correspondientes de tus contadores de puestos comerciales.
+        - name: "Paso 4: Obtener Fondos Iniciales."
+          text: Coloca 3 guerreros en zona de pagos.
+        - name: "Paso 5: Precios inicialesI"
+          text: Coloca 1 marcador de servicio en cualquier espacio de cada uno de tus contadores de servicios.
 
     - name: Alba
-      pretext: Tu Alba tiene 3 pasos en el siguiente orden.
+      pretext: Tu Alba tiene tres pasos en el siguiente orden.
       children:
         - name: Proteccionismo.
-          text: Si tu zona de Pagos está vacía, coloca 2 guerreros en ella.
-        - name: Puntuar dividendos.
-          text: Si hay algún puesto comercial sobre el mapa, puntúa 1 punto de victoria por cada 2 fondos. _(No puntúes por los guerreros en tu zona de Pagos o Consignados)_
-        - name: Recoger Fondos.
-          text: Coloca todos los guerreros de tu tablero de facción sobre la zona de Fondos.
+          text: Si la zona de pagos está vacía, coloca 2 guerreros en ella.
+        - name: Dividendos.
+          text: Si hay al menos un puesto comercial en el mapa, obtén un punto de victoria por cada 2 fondos. No obtienes puntos por los guerreros en la zona de pagos ni la zona de consignados.
+        - name: Fondos.
+          text: Mueve todos los guerreros en tu tablero a la zona de fondos.
 
     - name: Día
-      pretext: Puedes consignar y gastar fondos para realizar acciones, como se detalla a continuación, en la cantidad y orden que desees. Al consignar un fondo, mueve el guerrero a la zona de Consignados. Al gastar un fondo, devuelve el guerrero a la reserva de su propietario.
+      pretext: Puedes consignar y gastar fondos para realizar acciones como sigue, en cualquier orden y número. Cuando consignas un fondo, mueve el guerrero a la zona de consignados. Cuando gastas un fondo, devuelve el guerrero a la reserva de su propietario.
       children:
         - name: Mover.
-          text: Consigna un fondo para realizar un movimiento.
+          text: Consigna un fondo para hacer un movimiento.
         - name: Batallar.
           text: Consigna un fondo para iniciar una batalla.
         - name: Fabricar.
-          text: Consigna fondos para fabricar una carta de tu mano. En lugar de colocar estos guerreros sobre las casillas vacías del contador o los contadores de los Puestos Comerciales correspondientes a los palos que marca el coste de fabricación _(en la práctica, cada guerrero colocado cubre un icono de fabricación de dicho palo, funcionando de forma similar a otras piezas de fabricación)_
+          text: Consigna fondos para fabricar una carta de tu mano. En vez de mover a estos guerreros a la zona de consignados, debes colocarlos en espacios vacíos de los contadores de puestos comerciales correspondientes a los palos indicados en el coste de fabricación.
           subchildren:
             - name: Exportar.
-              text: Puedes ignorar el efecto de fabricación de una carta para, en su lugar, descartarla y colocar uno de tus guerreros de tu reserva en la zona de Pagos.
+              text: Puedes ignorar el beneficio asociado a la fabricación de una carta, descartarla y colocar un guerrero de La Compañía en la zona de pagos.
         - name: Robar.
           text: Consigna un fondo para robar una carta.
         - name: Reclutar.
-          text: Gasta un fondo para colocar un guerrero en cualquier claro en que haya un río.
-        - name: Establecer puesto comercial con guarnición.
+          text: Gasta un fondo para colocar un guerrero en un claro con un río.
+        - name: Puesto Comercial con Guarnición.
           text: Gasta dos fondos para colocar un puesto comercial y un guerrero.
           subchildren:
-            - name: Elige claro.
-              text: Elige cualquier claro en que no haya ya un puesto comercial, independientemente de quién gobierne.
-            - name: Gasta Fondos.
-              text: Gasta 2 fondos del jugador que gobierna el claro elegido.
-            - name: Coloca y puntúa.
-              text: Coloca el puesto comercial correspondiente al claro y un guerrero sobre el claro elegido. Puntúa los puntos de victoria indicados en la casilla recién descubierta del contador del puesto comercial de tu tablero de facción.
+            - name: Elegir Claro.
+              text: Escoge un claro que no tenga un puesto comercial gobernado por cualquier jugador.
+            - name: Gastar Fondos.
+              text: Gasta dos fondos del jugador que gobierna el claro elegido.
+            - name: Colocar y Puntuar.
+              text: Coloca el puesto comercial correspondiente y un guerrero en el claro elegido. Obtén los puntos de victoria indicados en el espacio descubierto de tu tablero.
 
     - name: Noche
-      pretext: Tu Noche tiene 2 pasos en el siguiente orden.
+      pretext: Tu Noche tiene dos pasos en el siguiente orden.
       children:
-        - name: Descartar cartas.
-          text: Si tienes más de 5 cartas en tu mano, descarta las cartas que elijas hasta tener solo 5.
-        - name: Ajustar costes.
-          text: Puedes mover el marcador de servicios de cada servicio y colocarlo sobre cualquier casilla de su correspondiente contador, estableciendo así un nuevo precio para cada servicio.
+        - name: Descartar.
+          text: Si tienes más de cinco cartas en tu mano, descarta cartas a tu elección hasta quedarte con cinco.
+        - name: Establecer Costes.
+          text: Puedes mover cada marcador de servicio a cualquier espacio de su contador, estableciendo un nuevo coste para ese servicio.
 
 - name: El Ducado Subterráneo
   color: "#eec4ab"

--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -685,7 +685,7 @@
                 - name: Golpes Recibidos.
                   text: El comprador debe repartir los impactos, sufriendo los golpes impares retirando guerreros de su propiedad _(no de la Compañía)_, si quedan, o edificios de su propiedad o fichas sólo si no tiene guerreros _(incluyendo de la Compañía)_ en el claro de batalla.
                 - name: El Vagabundo y los Mercenarios.
-                  text: El Vagabundo no puede comprar mercenarios de la Compañía _(Si el comprador ataca al Vagabundo y se retira un mercenario de la Compañía, la facción del comprador se convierte en Hostil, no La Compañía)_.
+                  text: El Vagabundo no puede comprar mercenarios de la Compañía _(Si el comprador ataca al Vagabundo y se retira un mercenario de la Compañía, la facción del comprador se convierte en Hostil, no la Compañía)_.
 
     - name: Preparación
       children:
@@ -721,7 +721,7 @@
           text: Consigna fondos para fabricar una carta de tu mano. En vez de mover a estos guerreros a la zona de consignados, debes colocarlos en espacios vacíos de los contadores de puestos comerciales correspondientes a los palos indicados en el coste de fabricación.
           subchildren:
             - name: Exportar.
-              text: Puedes ignorar el beneficio asociado a la fabricación de una carta, descartarla y colocar un guerrero de La Compañía en la zona de pagos.
+              text: Puedes ignorar el beneficio asociado a la fabricación de una carta, descartarla y colocar un guerrero de la Compañía en la zona de pagos.
         - name: Robar.
           text: Consigna un fondo para robar una carta.
         - name: Reclutar.

--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -10,7 +10,7 @@
         - name: Uso de **no puedes**.
           plainName: Uso de No puedes.
           text: Cualquier regla que diga **No puedes** o **No se puede** es absoluta. No puede ignorarse a menos que se especifique explícitamente.
-        - name: Resoluciones y elecciones poco claras
+        - name: Resoluciones y elecciones poco claras.
           text: Siempre que no esté claro en qué orden se deben resolver dos efectos simultáneos, o qué jugador debe actuar primero, el jugador en turno decide.
 
     - name: Información Pública y Privada.
@@ -30,7 +30,7 @@
       children:
         - name: Turno.
           text: Cada turno de un jugador consta de tres fases: Alba, Día y Noche. Cualquier texto que diga "al principio de" una fase, sucede antes de cualquier otra cosa en esa fase, si el texto dice "al final de" sucede después de todo lo demás en esa fase y justo antes del inicio de la siguiente, si la hay. Después de que un jugador finalice su Noche, el siguiente jugador en sentido horario comienza su turno. El juego continúa hasta que un jugador gana la partida (`rule:3.1`).
-        - name: Interrumpir
+        - name: Interrumpir.
           text: No puedes interrumpir una acción _(incluso una múltiple como la Marcha del Marquesado)_, habilidad _(como la Exposición de los Córvidos)_ o efecto persistente _(como la carta Emigrante del Nido)_ con otro efecto a menos que se permita explícitamente. _(Por ejemplo, la carta Pertrechados dice que se usa "En batalla...")_
     - name: Piezas
       children:
@@ -153,12 +153,12 @@
               text: El atacante puede jugar también una carta de emboscada correspondiente al claro de batalla. De ser así, ambos jugadores descartan sus cartas de emboscada sin aplicar sus efectos y se omite el paso `rule:4.3.1.2`.
             - name: Resuelve la Emboscada.
               text: El defensor da inmediatamente dos golpes al atacante (`rule:4.3.4`). Después, el defensor descarta la carta de emboscada. Si no quedan guerreros o peones atacantes, la batalla finaliza inmediatamente.
-        - name: "Paso 2: Tirar Dados"
+        - name: "Paso 2: Tirar Dados."
           text: Tira ambos dados. El atacante golpeará tantas veces como la tirada más alta, y el defensor golpeará tantas veces como la tirada más baja. Si las tiradas son iguales, el atacante y el defensor golpearán el mismo número de veces _(el uso del futuro aquí refleja que los golpes no se aplican hasta el paso 4)_. `faction:woodland:8.2.2`
           subchildren:
             - name: Golpes Máximos por Tirada.
               text: El número máximo de golpes que puedes causar debido a tu tirada es igual al número de tus guerreros en el claro de batalla, ya seas el atacante o el defensor. `faction:vagabond:9.2.6`
-        - name: "Paso 3: Usar Efectos"
+        - name: "Paso 3: Usar Efectos."
           text: El atacante y el defensor pueden usar efectos opcionales _(como la carta Tácticas Brutales)_ que afecten a la batalla. Si ambos quieren hacerlo, el atacante escoge quién los usa primero (`rule:1.1.3`).
           subchildren:
             - name: Golpes Adicionales.
@@ -174,7 +174,7 @@
   children:
     - name: Preparación Estándar
       children:
-        - name: "Paso 1: Asignar Facciones y Jugador Inicial"
+        - name: "Paso 1: Asignar Facciones y Jugador Inicial."
           text: Asigna una facción a cada jugador usando cualquier método. Determina al azar el orden de asiento y el jugador inicial, el orden de turno va hacia su izquierda. Cada jugador toma su tablero de facción y todas sus piezas, tal y como se describe en la parte trasera del mismo.
         - name: "Paso 2: Colocar Marcadores de Puntuación."
           text: Cada jugador coloca su contador de puntuación en la casilla "0" del contador.
@@ -197,56 +197,56 @@
   icon: marquise
   children:
     - name: Resumen
-      pretext: El Marquesado de Gato aspira a gobernar el bosque, que pretende transformar en una potencia militar e industrializada. Cada vez que el Marquesado construye uno de sus **edificios** -un taller, aserradero o reclutador- obtiene puntos de victoria. Cuantos más edificios de un tipo tenga sobre el mapa, más puntuará el siguiente. Sin embargo, para alimentar su ritmo de construcción, el Marquesado debe mantener y proteger su red de suministro de **madera**.
+      pretext: El Marquesado Gatuno gobierna el Bosque y quiere convertirlo en su reserva militar e industrial. Cada vez que el Marquesado construya uno de sus **edificios** _(un taller, un aserradero, o un reclutador)_ obtiene puntos de victoria. Cuantos más edificios del mismo tipo tenga en el mapa, más puntos obtiene. Sin embargo, para continuar alimentando ese ritmo de construcción, el Marquesado debe mantener y proteger una economía de **madera** fuerte e interconectada.
 
     - name: Reglas y Habilidades de Facción
       children:
         - name: Fabricar.
-          text: El Marquesado fabrica al inicio de su Día activando talleres.
+          text: El Marquesado fabrica durante el Día activando talleres.
         - name: La Fortaleza.
-          text: La Fortaleza. Solo el Marquesado puede colocar piezas sobre el claro que contenga la Fortaleza _(no obstante, sí es posible mover piezas a dicho claro)_. Si la Ficha de fortaleza es retirada en batalla, descártala de la partida de forma permanente.
-        - name: Hospitales de campaña.
-          text: Cada vez que cualquier cantidad de guerreros del Marquesado sean retirados de un claro en batalla, el Marquesado puede utilizar una carta del palo de dicho claro para colocar los guerreros retirados sobre el claro que contenga la Fortaleza.
+          text: El Marquesado puede colocar piezas en el claro donde está la ficha de la fortaleza, y los demás jugadores no pueden. _(Las piezas pueden acceder a ese claro moviendo. Si la ficha de la fortaleza es retirada se devuelve a la caja, no puede volver al mapa de nuevo)_.
+        - name: Hospitales de Campaña.
+          text: Cuando cualquier número de guerreros del Marquesado sean retirados de un claro, el Marquesado puede gastar una carta correspondiente a dicho claro para colocar a esos guerreros en el claro de la fortaleza en vez de retirarlos a su reserva personal.
 
-    - name: Preparación Individual
+    - name: Preparación
       children:
-        - name: "Paso 1: Guerreros y Madera."
-          text: Forma la reserva de guerreros (25 guerreros) y la de madera (8 fichas).
-        - name: "Paso 2: La Fortaleza."
-          text: Coloca la ficha de la Fortaleza en uno de los claros que hacen esquina en el mapa, a tu elección.
+        - name: "Paso 1: Juntar Guerreros y Madera."
+          text: Forma la reserva de guerreros (25) y fichas de madera (8).
+        - name: "Paso 2: Colocar La Fortaleza."
+          text: Coloca la ficha de la fortaleza en un claro de una esquina a tu elección. Este es tu claro inicial.
         - name: "Paso 3: Guarnición."
-          text: Coloca un guerrero en cada claro excepto en el claro que esté en la esquina opuesta al del claro donde has colocado tu Fortaleza.
-        - name: "Paso 4: Edicifios iniciales."
-          text: Coloca 1 aserradero, 1 taller y 1 reclutador. Puedes colocar estos edificios tanto en el claro de la Fortaleza como en cualquier claro adyacente a este, combinándolos como prefieras.
-        - name: "Paso 5: Rellenar los contadores de edificios."
-          text: Coloca tus 5 aserraderos, 5 talleres y 5 reclutadores restantes sobre las casillas correspondientes de sus respectivos contadores, de derecha a izquierda _(tapando  todas las casillas salvo la casilla más a la izquierda de cada fila)_.
+          text: Coloca un guerrero en cada claro excepto en el claro que está en la esquina diagonalmente opuesta al claro de la ficha de fortaleza.
+        - name: "Paso 4: Colocar los Edificios Iniciales."
+          text: Coloca 1 aserradero, 1 taller y 1 reclutador. Puedes colocarlos en el claro de la ficha de fortaleza o en claros adyacentes, en cualquier combinación.
+        - name: "Paso 5: Rellenar Contadores."
+          text: Coloca tus 5 aserraderos, 5 talleres y 5 reclutadores restantes en sus correspondientes contadores de edificios de derecha a izquierda. _(Deja vacío el espacio más a la izquierda de cada contador)_.
 
     - name: Alba
-      pretext: Coloca 1 ficha de madera por aserradero en los claros en que haya aserraderos construidos.
+      pretext: Coloca fichas de madera en cada claro que contenga al menos un aserradero, siendo el número de fichas de madera a colocar igual al número de aserraderos en ese claro.
 
     - name: Día
-      pretext: En primer lugar, puedes activar tus talleres para fabricar cartas de tu mano. Después, puedes realizar hasta tres acciones, más una acción por cada carta de ave que gastes específicamente para ello _(no como parte de una acción)_, en cualquier orden y número.
+      pretext: Primero, puedes activar talleres para fabricar cartas de tu mano. Después, puedes llevar a cabo hasta tres acciones en cualquier orden y número,y puedes llevar a cabo acciones extra gastando una carta de ave de tu mano por cada acción extra.
       children:
         - name: Batallar.
           text: Inicia una batalla.
         - name: Marchar.
-          text: Realiza hasta dos movimientos.
+          text: Haz hasta dos movimientos.
         - name: Reclutar.
-          text: Coloca 1 guerrero en cada reclutador. Solo puedes realizar esta acción una vez por turno.
+          text: Coloca un guerrero en cada reclutador. Solo puedes hacer esto una vez por turno.
         - name: Construir.
           text: Coloca un edificio.
           subchildren:
-            - name: Elige edificio
-              text: Elige el tipo de edificio que quieres construir (aserradero, taller o reclutador). Elige el edificio de ese tipo situado más a la izquierda de su contador. La columna correspondiente a ese edificio indica su coste de madera.
-            - name: Elige claro y paga madera.
-              text: Elige cualquier claro que gobiernes. Retira tantas fichas de madera como coste tenga el edificio del claro en que vas a construir, de los claros adyacentes a este en los que gobiernes o de cualquier claro gobernado por ti conectado al claro seleccionado a través de cualquier número de claros en los que gobiernes. _(Básicamente, debes gobernar toda la cadena de claros conectados al claro elegido para poder hacer uso de la Madera)_.
-            - name: Coloca el edificio y puntúa.
-              text: coloca el edificio elegido sobre el claro elegido, y puntúa los puntos de victoria que indica el espacio que ocupaba dicho edificio en tu tablero de facción.
+            - name: Escoger Claro y Edificio.
+              text: elige un claro que gobiernes. Elige si quieres colocar un aserradero, un taller o un reclutador. Colocarás el edificio de más a la izquierda de ese tipo de tu tablero de facción. Tienes que poder pagar su coste (`rule:6.5.4.2`) y colocarlo (`rule:6.5.4.3`).
+            - name: Pagar el Coste.
+              text: El coste del edificio escogido se muestra en la parte superior de su columna. Retira del mapa tantas fichas de madera como el coste, pudiendo estar dichas fichas en el claro elegido, en cualquier claro adyacente a él que gobiernes o en cualquier claro que gobiernes conectado al claro elegido únicamente a través de claros gobernados por ti.
+            - name: Colocar el Edificio y Puntuar.
+              text: Coloca el edificio elegido sobre el claro escogido y obtén los puntos de victoria indicados en el espacio que se ha descubierto en tu tablero de facción.
         - name: Forzar Producción.
-          text: Gasta una carta del palo correspondiente al claro donde haya construido un aserradero para producir 1 Madera allí.
+          text: Gasta una carta correspondiente al claro de un aserradero, para colocar una ficha de madera adicional ahí.
 
     - name: Noche
-      pretext: Roba 1 carta, más 1 por cada icono de robar carta descubierto sobre tu tablero de facción. Después, si tienes más de 5 cartas en tu mano, descarta cartas a tu elección hasta quedarte con solo 5.
+      pretext: Roba una carta, más una carta adicional por cada símbolo de robo adicional descubierto. Entonces, si tienes más de cinco cartas en tu mano, descarta cartas a tu elección hasta quedarte con cinco.
 
 - name: El Nido de Águilas
   color: "#416eb0"

--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -345,94 +345,94 @@
   icon: woodland
   children:
     - name: Resumen
-      pretext: La Alianza trabaja para ganarse la **simpatía** de las diversas comunidades del Bosque desencantadas con su situación actual. Cada vez que la Alianza coloca una ficha de simpatía, obtendrá puntos de victoria. Cuanta más simpatía haya extendido por el mapa, más puntuará. Obtener la simpatía de las masas requiere de **simpatizantes**. Estos simpatizantes también pueden utilizarse con fines violentos y revolucionarios, incitando a la rebelión por el bosque. Cuando se  produzca una **revuelta**, la Alianza establecerá una **base**. Las bases permiten a la Alianza entrenar oficiales, lo cual aumenta su flexibilidad militar.
+      pretext: La Alianza trabaja para obtener la **simpatía** de las variadas criaturas del bosque que están descontentas con la situación actual. Cada vez que la Alianza coloca una ficha de simpatía, puede obtener puntos de victoria. Cuanta más simpatía tenga en el mapa, más puntos de victoria obtiene. Ganas simpatía de las gentes requiere **simpatizantes**. Estos simpatizantes también se pueden utilizar con un fin violento, incitando a la rebelión por todo el Bosque. Cuando ocurra una revuelta, la Alianza establecerá una **base**. Las bases le permiten a la Alianza entrenar oficiales, incrementando su flexibilidad militar.
 
     - name: Reglas y Habilidades de Facción
       children:
         - name: Fabricar.
-          text: La Alianza fabrica durante Día activando fichas de simpatía.
-        - name: Guerrilla.
-          text: Como defensor en batalla, la Alianza toma siempre el resultado del dado más alto, y el atacante el del dado más bajo para determinar cuántos impactos causan.
-        - name: La pila de Simpatizantes.
-          text: Para realizar sus acciones, la Alianza gasta **simpatizantes**, que son las cartas de la pila de simpatizantes. Los Simpatizantes solo se pueden gastar por su palo y no cuentan como cartas en mano. Las cartas de la pila de simpatizantes se colocan bocabajo, ocultas al resto de jugadores, aunque la Alianza puede revisar la pila siempre que quiera.
+          text: La Alianza fabrica durante Día, activando fichas de simpatía.
+        - name: Guerra de Guerrillas.
+          text: Como defensor en batalla, la Alianza golpea con la tirada más alta, y el atacante con la tirada más baja.
+        - name: Simpatizantes.
+          text: Para llevar a bao acciones durante el Alba, la Alianza gasta **simpatizantes**, que son las cartas de su montón de simpatizantes. Los simpatizantes solo pueden gastarse por el palo y no cuentan para el límite de mano de la Alianza. Los simpatizantes están bocabajo, pero la Alianza puede examinarlos en cualquier momento.
           subchildren:
-            - name: Límite de capacidad.
-              text: Si la Alianza no tiene bases sobre el mapa, en la pila de simpatizantes solo puede haber un máximo de 5 cartas. En caso de que la Alianza obtenga un simpatizante pero no pudiese albergar más, deberá descartar dicha carta. Si la Alianza tiene al menos una base sobre el mapa, entonces la pila de Seguidores no tiene límite de capacidad.
+            - name: Capacidad.
+              text: Si la Alianza no tiene bases en el mapa, el montón de simpatizantes sólo puede tener hasta cinco cartas. Si la Alianza fuera a ganar un simpatizante pero no tiene espacio en el montón, esa carta se descarta. Si hay al menos una base en el mapa, el montón de simpatizantes no tiene límite de cartas.
         - name: Retirar Bases.
-          text: Cuando una de sus bases sea retirada, la Alianza debe descartar todos los seguidores del palo correspondiente a dicha base (las cartas de ave también), y retirar la mitad de sus oficiales, redondeando hacia arriba. Si la Alianza no tuviese ninguna base sobre el mapa y en la pila de seguidores hubiese más de cinco cartas, deberá descartar cartas hasta tener solo cinco.
+          text: Cuando se retire una base, la Alianza debe descartar todos sus simpatizantes del palo correspondiente al indicado por la base _(aves incluidas)_, y retirar la mitad de sus oficiales, redondeado hacia arriba. Si la alianza no tiene más bases en el mapa y tiene más de cinco simpatizantes, debe descartarse hasta quedarse con cinco.
         - name: Fichas de Simpatía.
           text: La Alianza tiene 10 fichas de simpatía.
           subchildren:
-            - name: Límite de colocación.
-              text: Cada claro solo puede contener 1 ficha de simpatía.
-            - name: Términos clave asociados.
-              text: Un **claro afín** es cualquier claro con una ficha de simpatía. Un claro **no afín** es cualquier claro sin ficha de simpatía.
+            - name: Límite de Colocación.
+              text: Cada claro solo puede tener una única ficha de simpatía.
+            - name: Términos.
+              text: Un **claro afín** es uno con ficha de simpatía. Un **claro no afín** es uno sin ficha de simpatía.
         - name: Indignación.
-          text: Cuando cualquier otro jugador retire una ficha de simpatía de un claro afín o mueve guerreros a un claro afín, debe añadir una carta del palo correspondiente a tu pila de Simpatizantes. Si dicho jugador no tuviese cartas de dicho palo _(ni tampoco de ave)_ debe mostrar su mano a la Alianza, y después la Alianza debe robar 1 carta del mazo y añadirla a su pila de Simpatizantes.
+          text: Cuando otro jugador retira una ficha de simpatía o mueve guerreros a un claro afín, debe añadir una carta correspondiente al claro afectado de su mano al montón de simpatizantes. Si no tiene ninguna carta correspondiente _(ni aves)_, debe enseñarle su mano a la Alianza, y entonces la Alianza roba una carta del mazo y la añade a su montón de simpatizantes.
 
-    - name: Preparación Individual
+    - name: Preparación
       children:
-        - name: "Paso 1: Guerreros."
-          text: Forma una reserva de 10 guerreros.
-        - name: "Paso 2: Preparar Bases."
-          text: Coloca tus 3 bases sobre sus respectivas casillas de tu zona de Bases.
-        - name: "Paso 3: Contador de Simpatía."
-          text: Coloca tus 10 fichas de simpatía sobre las respectivas casillas del contador de simpatía.
-        - name: "Paso 4: Simpatizantes iniciales."
-          text: Roba 3 cartas y colócalas bocabajo en tu pila de Simpatizantes.
+        - name: "Paso 1: Juntar Guerreros."
+          text: Forma la reserva de guerreros (10).
+        - name: "Paso 2: Colocar Bases."
+          text: Coloca 3 bases en los espacios correspondientes de tu zona de bases.
+        - name: "Paso 3: Rellenar el Contador de Simpatía."
+          text: Coloca allí 10 fichas de simpatía.
+        - name: "Paso 4: Obtener Simpatizantes."
+          text: Roba 3 cartas y colócalas bocabajo en tu montón de simpatizantes.
         
     - name: Alba
-      pretext: Tu Alba tiene 2 pasos en el siguiente orden.
+      pretext: Tu Alba tiene dos pasos en el siguiente orden.
       children:
         - name: Revuelta.
-          text: Retira todas las piezas enemigas de un claro y coloca una base y los guerreros que corresponda, como se indica a continuación. Puedes realizar tantas revueltas como quieras, siempre que cumplas las condiciones.
+          text: Puedes hacer la acción de Revuelta cualquier número de veces según se indica.
           subchildren:
-            - name: Elige claro.
-              text: Solo es posible realizar la Revuelta en un claro afín de un palo cuya base no esté ya construida _(no es posible realizar la revuelta en un claro de un palo si la base correspondiente ya está construida)_.
-            - name: Gastar Simpatizantes.
-              text: Gasta dos seguidores del palo correspondiente al palo del claro en que realizas la Revuelta.
-            - name: Resolver efecto.
-              text: Retira todas las piezas enemigas del claro elegido. Después, coloca la base correspondiente al palo de dicho claro y tantos guerreros como claros afines de ese palo tengas. Después, coloca un guerrero de tu reserva en el recuadro de Oficiales; este es ahora un **oficial**. _(Recuerda que obtienes 1 punto de victoria por cada ficha o edificio que retires en la revuelta, y a determinadas facciones se les aplican reglas específicas para las bajas por este efecto)_
+            - name: "Paso 1: Elegir Claro."
+              text: Elige un claro afín correspondiente a una base que esté en tu tablero de facción.
+            - name: "Paso 2: Gastar Simpatizantes."
+              text: Gasta dos simpatizantes correspondientes al claro elegido.
+            - name: "Paso 3: Resolución."
+              text: Retira todas las piezas enemigas del claro elegido _(obtén puntos de victoria por ficha o edificio retirado)_. Después coloca allí tu base correspondiente y tantos guerreros como claros afines en el mapa correspondientes al palo indicado por la base. Por último, coloca un guerrero en la zona de Oficiales. Este guerrero es ahora un **oficial**.
 
-        - name: Extender Simpatía.
-          text: Coloca una ficha de Simpatía, siguiendo las normas descritas a continuación. Puedes extender simpatía tantas veces como quieras.
+        - name: Extiende Simpatía.
+          text: Puedes Extender Simpatía cualquier número de veces de la forma siguiente.
           subchildren:
-            - name: Elige claro.
-              text: Elige cualquier claro no afín adyacente a un claro afín. En caso de no haber ningún claro afín, puedes elegir cualquier claro.
-            - name: Gastar Simpatizantes.
-              text: Gasta simpatizantes del palo correspondiente a dicho claro. La cantidad de simpatizantes que debes gastar aparece indicada encima de la ficha, en el contador.
+            - name: "Paso 1: Elegir Claro."
+              text: Elige un claro no afín adyacente a un claro afín. Si no hay claros afines, puedes elegir cualquier claro.
+            - name: "Paso 2: Gastar Simpatizantes."
+              text: Gasta simpatizantes correspondientes al claro elegido. El número de simpatizantes que debes gastar está indicado sobre la ficha de simpatía que colocas.
               subchildren:
                 - name: Ley Marcial.
-                  text: Debes gastar un simpatizante adicional si en el claro elegido hay algún jugador con 3 guerreros o más.
-            - name: Resolución.
-              text: Coloca la ficha de Simpatía sobre el claro elegido y suma los puntos de victoria indicados sobre el espacio que ocupaba la ficha en el contador.
+                  text: Debes gastar un simpatizante correspondiente adicional si el claro elegido tiene al menos 3 guerreros de otro jugador, incluyendo guerreros que se estén tratando como suyos para gobernar _(mercenarios, secuaces, etc.)_.
+            - name: "Paso 3 Colcoar y Puntuar."
+              text: Coloca una ficha de simpatía en el claro elegido. Obtén los puntos de victoria indicados en el espacio que acabas de revelar en tu tablero de facción.
 
     - name: Día
-      pretext: Puedes realizar las siguientes acciones en cualquier orden y combinación.
+      pretext: Puedes hacer las siguientes acciones en cualquier orden y número.
       children:
         - name: Fabricar.
           text: Puedes activar fichas de simpatía para fabricar cartas de tu mano.
         - name: Mobilizar.
-          text: Añade una carta de tu mano a la pila de Simpatizantes.
+          text: Añade una carta de tu mano al montón de simpatizantes.
         - name: Entrenar.
-          text: Gasta una carta del palo correspondiente a una base construida sobre el mapa para colocar un guerrero de la reserva en el recuadro de Oficiales. Este guerrero es ahora un **oficial**.
+          text: Gasta una carta correspondeinte al palo indicado por una base en el mapa para colocar un guerrero en la zona de oficiales. Este guerrero ahora es un **oficial**.
 
     - name: Noche
-      pretext: Tu Noche tiene 2 pasos en el siguiente orden.
+      pretext: Tu Noche tiene dos pasos en el siguiente orden.
       children:
-        - name: Operaciones militares.
-          text: Puedes realizar tantas acciones de estas como oficiales tengas, en cualquier orden y combinación.
+        - name: Operaciones Militares.
+          text: Puedes llevar a cabo acciones, de las siguientes, siendo el número máximo de acciones tu número de oficiales, en cualquier orden y número.
           subchildren:
             - name: Mover.
-              text: Realiza un movimiento.
+              text: Haz un movimiento.
             - name: Batallar.
               text: Inicia una batalla.
             - name: Reclutar.
-              text: Coloca un guerrero en cualquier claro en el que haya un base.
+              text: Coloca un guerrero en cualquier claro que tenga una base.
             - name: Organizar.
-              text: Retira 1 de tus guerreros de un claro no afín, coloca una ficha de simpatía en dicho claro, y puntúa los puntos de victoria indicados en casilla recién descubierta del contador de simpatía.
-        - name: Robar y descartar.
-          text: Roba 1 carta, más 1 por cada icono de robar carta descubierto sobre tu tablero de facción. Después, si tienes más de 5 cartas en tu mano, descarta cartas a tu elección hasta quedarte con solo 5.
+              text: Retira un guerrero de la alianza de un claro no afín, coloca una ficha de simpatía allí y obtén los puntos de victoria indicados en el espacio que acabas de descubrir en el contador de simpatía.
+        - name: Robar y Descartar.
+          text: Roba una carta, más una carta adicional por cada símbolo de robo adicional descubierto. Entonces, si tienes más de cinco cartas en tu mano, descarta cartas a tu elección hasta quedarte con cinco.
 
 - name: Vagabundo
   color: "#6d6e70"

--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -576,72 +576,72 @@
   icon: cult
   children:
     - name: Resumen
-      pretext: Atendiendo a las criaturas descartadas por otras facciones del Bosque, el Culto Reptiliano trata de abrumar a sus enemigos a través de su obstinada determinación. Si el Culto gobierna claros, puede construir **jardines**, difundiendo su evangelio por el boca pico entre los animales que viven allí. Cuanto más seguidores consiga, más puntos podrá puntuar completand los **rituales** pertinentes. Mientras otras facciones gastan cartas para cumplir sus objetivos, el culto principalmente las revela y gradualmente las va seleccionando para conformar su grupo ideal de fieles. A no ser que se usen para puntuar, las cartas reveladas vuelven a la mano de del Culto en su Noche. Sin enmbargo, este enfoque más amable hace que mover y batallar se más complicado, así que solo pueden ser llevadas a cabo por los miembros más radicalizados del Culto, los **acólitos**, obtenidos al perder guerreros en batalla.
+      pretext: El Culto Reptiliano trata de abrumar a sus enemigos a través de fuerza de volutand bruta, y para ello utiliza a las criaturas descartadas del Bosque. En los claros que bogierna el Culto puede construir **jardines**, con los que aumenta el boca a pico para difundir su evangelio. Cuanto mayor sea su control sobre el corazón de sus fieles, el Culto obtendrá más puntos de victoria al completar ciertos **rituales**. Mientras que las otras facciones gastan cartas para lograr sus objetivos, el Culto principalmente revela cartas y gradualmente las va seleccionando para conseguir el conjunto ideal de seguidores. A no ser que se usen para puntuar, esas cartas no se gastan y vuelve a la mano del Culto durante la Noche. Sin embargo, este enfoque más amable hace que el movimiento y las operaciones de combate sean más difíciles, así que esas acciones sólo pueden ser llevadas a cabo por sus **acólitos** más radicalizados, obtenidos a medida que los guerreros del Culto son masacrados al defender en batallas.
 
     - name: Reglas y Habilidades de Facción
       children:
         - name: Fabricar.
-          text: El Culto fabrica durante la Noche activando talleres del palo **Paria** (`rule:10.4.1`).
-        - name: Odio a las aves.
-          text: Las cartas de Ave no se consideran comodín para los rituales del Culto.
+          text: El Culto fabrica durante la Noche activando los jardines cuyos palos son correspondientes al palo paria (`rule:10.4.1`). _(En general se corresponden con el claro, salvo por el Lugar Mítico la Ciudad Perdida)_.
+        - name: Odio a las Aves.
+          text: Las cartas de ave no son comodines para los rituales del Culto.
         - name: Venganza.
-          text: Cuando un guerrero del Culto es retirado al defender en batallas, este se coloca en la zona de Acólitos de su tablero en lugar de en la reserva.
+          text: Cuando un guerrero del Culto es retirado mientras defiende en batalla, se coloca en la zona de acólitos en lugar de la reserva del Culto.
         - name: Peregrinos.
-          text: El Culto gobierna cualquier claro en que tenga al menos un jardín. Esta regla domina sobre la regla "Señores del Bosque" del Nido de Águilas. (`rule:7.2.2`).
+          text: El Culto gobierna cualquier claro donde tenga un jardín. Esto invalida la regla Señores del Bosque (`rule:7.2.2`).
         - name: Miedo a los Fieles.
-          text: Cuando un jardín es retirado, el culto debe descartar una carta al azar.
-        - name: La pila de Almas Perdidas.
-          text: Cuando una carta sea descartada o gastada _(incluso una carta de Dominancia)_, esta se coloca en la pila de Almas Perdidas en lugar de en la pila de descarte. La Pila de Almas perdidas y las cartas que hay en ella son información pública.
+          text: Cuando un jardín es retirado del tablero, el Culto debe descartar una carta al azar.
+        - name: El Montón de Almas Perdidas.
+          text: Cuando una carta sea gastada o descartada _(incluso una carta de dominancia)_, colócala en el montón de lamas perdida en lugar de la pila de descarte. Las almas perdidas pueden ser inspeccionadas en cualquier momento por cualquier jugador.
 
-    - name: Preparación Individual
+    - name: Preparación
       children:
-        - name: "Paso 1: Guerreros."
-          text: Forma una reserva con tus 25 guerreros.
-        - name: "Paso 2: Guerreros y Jardín inicial"
-          text: En el claro de la esquina opuesta a la fortaleza del Marquesado o el nido inicial del Nido de Águilas, coloca 4 guerreros  y 1 jardín del palo del claro; si el Marquesado y el Nido de Águilas están en partida, elige el claro de 1 de las esquinas restantes. Después, coloca 1 guerrero en cada claro adyacente.
+        - name: "Paso 1: Juntar Guerreros."
+          text: Forma la reserva de guerreros (25).
+        - name: "Paso 2: Colocar Guerreros"
+          text: En un claro de una esquina que no sea el claro inicial de otro jugador y, si es posible, que sea diagonalmente opuesto a un claro inicial, coloca 4 guerreros y 1 jardín correspondiente al palo indicado por ese claro. Éste es tu claro inicial. Luego coloca 1 guerrero en cada claro adyacente a ese claro. _(Esto se ha actualizado con respecto a ediciones anteriores por flexibilidad)_.
         - name: "Paso 3: Elegir al Paria"
-          text: Coloca el marcador del paria sobre la casilla de cualquier palo del recuadro indicador del Paria. Dicho palo es ahora el **Paria**.
-        - name: "Paso 4: Contadores de Jardines."
-          text: Coloca tus 14 jardines restantes sobre los espacios correspondientes de tu contador de jardines, colocándolos de derecha a izquierda.
+          text: Coloca el marcador de paria sobre cualquier casilla de la zona paria. El palo que se encuentre en esa casilla pasa a ser el **paria**.
+        - name: "Paso 4: Rellenar los Contadores de Jardines."
+          text: Coloca tus 14 jardines restantes en los espacios correspondientes de tus contadores de jardines, de derecha a izquierda.
   
     - name: Alba
-      pretext: Tu Alba tiene 3 pasos en el siguiente orden.
+      pretext: Tu Alba tiene tres pasos en el siguiente orden.
       children:
         - name: Ajustar el Paria.
-          text: Mira las cartas de tu pila de Almas Perdidas, ignorando las cartas de ave. El palo con más cartas es el nuevo Paria. Desplaza el marcador para indicar cuál es el nuevo Paria. Si dicho palo ya era el Paria, entonces gira el marcador a su cara de **Odiado**. Si ningún palo tiene más cartas, el marcador permanece en su espacio actual y, si no está **Odiado** voltea el marcador a dicha cara.
+          text: Mira las cartas del montón de almas perdidas, ignorando las aves. El palo con más cartas en la pila se convierte en el nuevo paria _(mueve el marcador de paria, mostrando su cara de paria, a ese palo)_. Si ese palo ya era el paria, voltea el marcador a su cara de odiado. Si ningún palo tiene más cartas, el marcador se queda donde estaba y si no está en su cara de odiado, lo volteas para que ahora lo esté.
         - name: Descartar Almas Perdidas.
-          text: Descarta todas las cartas de la pila de Almas Perdidas a la pila de descarte. _(Las cartas de Dominancia están disponibles a partir de este momento)_
+          text: Descarta todas las cartas del montón de almas perdidas a la pila de descarte _(las cartas de dominancia pasan a estar disponibles)_.
         - name: Realizar Conspiraciones.
-          text: Puedes gastar acólitos, devolviéndolos a tu reserva personal, para realizar conspiraciones en claros del palo Paria, en cualquier orden y combinación, como se indica a continuación. Si el Paria es Odiado, las conspiraciones cuestan un acólito menos. Para realizar las acciones de Convertir o Santificar debes poder completar acción.
+          text: Puedes gastar acólitos, devolviéndolos a tu reserva, para conspirar en claros correspondientes al paria, en cualquier orden y número, de la manera siguiente. Si el paria es odiado, cada conspiración te cuesta un acólito menos.
           subchildren:
             - name: Cruzada.
-              text: Gasta 2 acólitos para iniciar batalla en un claro del palo Paria **o bien** para mover _(al menos un guerrero)_ desde un claro Paria y, después, si quieres, iniciar batalla en el claro de destino.
+              text: Gasta dos acólitos para iniciar una batalla en un claro de paria o bien para mover al menos un guerrero desde un claro paria y luego, si lo deseas, iniciar una batalla en el claro de destino.
             - name: Convertir.
-              text: Gasta 2 acólitos para retirar un guerrero enemigo de un claro Paria y después colocar un guerrero tuyo en dicho claro.
+              text: Gasta dos acólitos para reemplazar un guerrero enemigo de un claro de paria por un guerrero del Culto. _(Para reemplazar una pieza, debes poder retirar la previa y colocar una nueva)_.
             - name: Santificar.
-              text: Gasta 3 acólitos para retirar un edificio enemigo de un claro Paria y colocar un jardín del palo del claro en su lugar.
+              text: Gasta tres acólitos para reemplazar un edificio enemigo de un claro de paria por un jardín correspondiente.
 
     - name: Día
-      pretext: Puedes revelar tantas cartas de tu mano como desees _(colócalas temporalmente sobre tu área de juego)_, y realizar un ritual per carta revelada, del tipo que desees y en el orden que quieras, como se indica a continuación. _(Las cartas reveladas no pueden ser utilizadas para ningún otro fin durante la fase del Día)_
+      pretext: Puedes revelar cualquier número de cartas de tu mano y llevar a cabo un ritual por cada carta revelada, en cualquier orden y número, de la manera siguiente. _(Las cartas reveladas de tu mano se sitúan bocarriba en tu zona de juego y no se pueden suar para ningún otro propósito durante el Día)_.
       children:
         - name: Construir.
-          text: Coloca un jardín del palo correspondiente a la carta revelada sobre un claro de dicho palo en el que gobiernes.
+          text: Coloca un jardín correspondiente a la carta revelada en un claro que gobiernes, también correspondiente a la carta revelada.
         - name: Reclutar.
-          text: Coloca un guerrero sobre un claro del palo de la carta revelada.
+          text: Coloca un guerrero sobre un claro correspondiente a la carta revelada.
         - name: Puntuar.
-          text: Gasta la misma carta que has revelado _(colocándola en la pila de Almas Perdidas)_ para puntuar tantos puntos de victoria como indique la casilla vacía más avanzada del contador de jardines de dicho palo. Solo puedes realizar esta acción una vez por palo en tu turno.
+          text: Gasta la carta que reveles _(colócala en almas perdidas)_ para obtener los puntos de victoria indicados sobre la casilla vacía que esté más a la derecha del contador de jardines correspondiente a la carta descartada. Sólo puedes realizar esta acción una vez por turno por cada palo.
         - name: Sacrificio.
-          text: Coloca un guerrero de tu reserva en el espacio de Acólitos. Para realizar este ritual debes revelar una carta de ave. _(Este es el único ritual que puedes realizar con una carta de ave)_
+          text: Coloca un guerrero en la zona de acólitos. Para realizar este ritual, debes revelar una carta de ave.
 
     - name: Noche.
-      pretext: Tu Noche tiene 3 pasos en el siguiente orden.
+      pretext: Tu Noche tiene tres pasos en el siguiente orden.
       children:
-        - name: Recuperar cartas reveladas.
-          text: Recupera todas las cartas que hayas revelado durante tu Día, devolviéndolas a tu mano.
+        - name: Recuperar Cartas.
+          text: Recupera todas las cartas reveladas en este turno y devuélvelas a tu mano.
         - name: Fabricar.
-          text: Puedes fabricar activando jardines del palo Paria.
-        - name: Robar y descartar.
-          text: Roba 1 carta, más 1 por cada icono de robar carta descubierto sobre tu tablero de facción. Después, si tienes más de 5 cartas en tu mano, descarta cartas a tu elección hasta quedarte con solo 5.
+          text: Puedes fabricar cartas de tu mano activando jardines cuyo palo corresponda con el palo paria.
+        - name: Robar y Descartar.
+          text: Roba una carta, más una carta adicional por cada símbolo de robo adicional descubierto. Entonces, si tienes más de cinco cartas en tu mano, descarta a tu elección hasta quedarte con cinco.
 
 - name: La Compañía del Río
   color: "#5bc3bd"

--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -839,85 +839,78 @@
         - name: Robar y Descartar.
           text: Roba una carta, más una carta adicional por cada símbolo de robo adicional descubierto. Entonces, si tienes más de cinco cartas en tu mano, descarta a tu elección hasta quedarte con cinco.
 
-- name: La Conspiración de los Córvidos
+- name: La Conspiración Córvida
   color: "#925da5"
   icon: corvid
   children:
     - name: Resumen
-      pretext: La Conspiración Córvida pretende someter a la comunidad del Bosque por medio de **conspiraciones** criminales, obteniendo puntos de victoria cada vez que revele una ficha. Cuantas más conspiraciones reveladas haya sobre el mapa, más puntuará. El engaño es absolutamente necesario; si sus planes son demasiado obvios, los Córvidos se arriesgan a ser expuestos. Para evitarlo, deberán reclutar con cautela aprovechar cualquier oportunidad para el subterfugio y la extorsión. 
+      pretext: La Conspiración Córvida busca forzar al Bosque a la sumisión llevando a cabo **planes** criminales y obteniendo puntos de victoria cada vez que voltean uno. Cuantos más planes haya revelados sobre el mapa, más puntos obtienen. Desviar la atención es crítico, ya que si sus intenciones son demasiado obvias, los Córvidos se arriesgan a ser expuestos. Para evitarlo deben reclutar con mucha cautela y buscar todas las oportunidades posibles para el subterfugio y la extorsión.
 
     - name: Reglas y Habilidades de Facción
       children:
         - name: Fabricar.
-          text: Los Córvidos fabrican durante el Alba activando fichas de conspiración _(bocarriba o bocabajo)_.
-
-        - name: Fichas de conspiración.
-          text: Los Córvidos tienen 8 fichas de conspiración, 2 de cada tipo.
+          text: Los Córvidos fabrican durante el Alba activando fichas de plan _(ya estén bocarriba o bocabajo)_.
+        - name: Fichas de Plan.
+          text: Los Córvidos tienen ocho fichas de plan, dos de cada tipo.
           subchildren:
-            - name: Estado de las fichas de conspiración.
-              text: Mientras estén en la reserva de los Córvidos, las fichas de conspiración se mantienen bocabajo _(mostrando el icono de la pluma)_. En el mapa, estas fichas pueden estar bocarriba _(mostrando su icono distintivo)_ o bocabajo. Los Córvidos pueden consultar sus fichas bocabajo en cualquier momento para comprobar de qué tipo son.
-            - name: Límite de colocación.
-              text: Cada claro solamente puede contener 1 ficha de conspiración.
-
-        - name: Gracilidad.
-          text: La Conspiración de los Córvidos puede mover independientemente de quién gobierne el claro de origen y el de destino.
-
+            - name: Sentido de la Ficha.
+              text: Mientras que estén en la reserva de los Córvidos, las fichas de plan están bocabajo _(pluma)_. Mientras está en el mapa, una ficha puede estar bocarriba _(ícono único)_ o bocabajo. Los córvidos pueden inspeccionar una ficha de plan que esté bocabajo en cualquier momento.
+            - name: Límites de Colocación.
+              text: Cada claro sólo puede tener una única ficha de plan.
+        - name: Grácil.
+          text: Los Córvidos pueden moverse independientemente de quién gobierne su claro de origen o de destino.
         - name: Exposición.
-          text: En cualquier momento durante su turno, pero siempre antes de robar cartas en su Noche, un jugador enemigo con al menos una pieza en un claro en el que haya una ficha de conspiración puede revelar a los Córvidos una carta del palo de dicho claro para intentar adivinar el tipo de ficha de conspiración de dicho claro. Si el intento de adivinar es incorrecto, los Córvidos simplemente deben decir "no" y el jugador enemigo debe dar dicha carta a los Córvidos. Si acierta, el jugador enemigo retira la ficha de conspiración _(y en consecuencia, suma 1 punto), ignorando el efecto de dicha ficha.
-
-        - name: Agentes encubiertos.
-          text: Como defensor en batalla, si los Córvidos tienen una ficha de conspiración en el claro de la batalla, causan 1 impacto adicional _(incluso aunque estén indefensos)_.
+          text: En cualquier momento de su turno, pero antes de robar cartas durante su Noche, un jugador enemiga con al menos una pieza de facción en un claro que contenga una ficha de plan bocabajo puede mostrarle una carta correspondiente a los Córvidos para intentar adivinar el tipo de ficha de plan de ese claro. Si no es correcto, los Córvidos dicen "no" y el jugador enemigo les da esa carta a los Córvidos. Si es correcto, el jugador enemigo retira la ficha de plan _(obteniendo un punto de victoria)_ y se ignora su efecto.
+        - name: Agentes Infiltrados.
+          text: Como defensor en la batalla, si los Córvidos tienen una ficha de plan bocabajo _(incluso si están indefensos)_ en el claro de batalla, dan un golpe adicional.
 
     - name: Preparación Individual
       children:
-        - name: "Paso 1: Guerreros y Conspiraciones."
-          text: Forma tus reservas con tus 15 guerreros y tus 8 fichas de conspiración colocadas bocabajo.
-
-        - name: "Paso 2: Dispersar guerreros."
-          text: Coloca 1 guerrero en un claro de cada palo, a tu elección _(en total, 3 guerreros en 3 claros)_.
+        - name: "Paso 1: Juntar Guerreros y Planes."
+          text: Forma la reserva de guerreros (15) y las fichas de planes bocabajo (8).
+        - name: "Paso 2: Dispersarse."
+          text: Coloca 1 guerrero en un claro cualquiera de cada palo _(3 en total)_.
 
     - name: Alba
-      pretext: Tu Alba tiene 3 pasos en el siguiente orden.
+      pretext: Tu Alba tiene tres pasos en el siguiente orden.
       children:
         - name: Fabricar.
-          text: Puedes activar fichas de conspiración _(no importa si están bocarriba o bocabajo)_ para fabricar cartas de tu mano _(siguiendo las reglas estándares, cada ficha puede ser utilizada una sola vez y cuenta por el palo del claro donde esté situada).
-        
-        - name: Revelar conspiraciones.
-          text: Puedes revelar conspiraciones tantas veces como desees, volteando bocarriba una ficha que esté bocabajo sobre el mapa en claros donde tengas al menos un guerrero _(no puedes revelar una conspiración si no tienes guerreros en dicho claro)_. Al revelar una conspiración, puntúa 1 punto de victoria por cada ficha de conspiración bocarriba sobre el mapa _(contando también la ficha recién revelada)_, y después resuelve el efecto de la conspiración si esta es una Bomba o una Extorsión.
-
+          text: Puedes activar fichas de plan _(estén bocarriba o bocabajo)_ para fabricar cartas de tu mano.
+        - name: Voltear Planes.
+          text: Tantas veces como quieras, voltea un plan para ponerlo bocarriba en un claro que tenga cualquier número de guerreros Córvidos y obtén un punto de victoria por cada ficha de plan sobre el mapa que esté bocarriba _(incluyendo la que acabas de voltear)_. Entonces resuelve el efecto de volteo si es una bomba o una extorsión.
         - name: Reclutar.
-          text: Una vez por turno, puedes gastar una carta para colocar 1 guerrero en cada claro del palo correspondiente. _(Si gastas una carta de ave, tú eliges el palo)_
+          text: Una vez por turno puedes gastar una carta cualquiera para colocar un guerrero en cada claro correspondiente. _(Si gastas un ave, elige un palo en el que colocar los guerreros)_.
 
     - name: Día
-      pretext: Puedes realizar hasta 3 acciones de las indicadas a continuación, en el orden y cantidad que desees.
+      pretext: Puedes realizar hasta tres acciones como sigue, en cualquier orden y número.
       children:
         - name: Mover.
-          text: Realiza un movimiento.
-        - name: Conspirar.
-          text: Retira, de un claro en que no haya ya una ficha de conspiración, 1 guerrero córvido, más otro guerrero por cada ficha de conspiración que hayas colocado este turno, para colocar una ficha de conspiración en dicho claro.
+          text: Haz un movimiento.
+        - name: Planear.
+          text: retira un guerrero Córvido, más otro guerrero Córvido por cada plan que ya hayas colocado este turno, de un claro que no tenga ficha de plan para colocar una ficha de plan bocabajo en él.
         - name: Batallar.
           text: Inicia una batalla.
-        - name: Truco.
-          text: Intercambia dos fichas de conspiración que estén sobre el mapa _(es posible realizar un intercambio "falso" y dejar las fichas como estaban)_. Ambas fichas deben estar o bocarriba o bocabajo.
+        - name: Trucar.
+          text: Intercambia dos fichas de plan sobre el mapa. Ambas fichas de plan deben estar bocarriba o bocabajo.
 
     - name: Noche
-      pretext: Tu Noche tiene 2 pasos en el siguiente orden.
+      pretext: Tu Noche tiene dos pasos en el siguiente orden.
       children:
-        - name: Esfuerzo.
-          text: Puedes optar por no robar cartas durante tu Noche para realizar una de las acciones de tu Día.
-        - name: Robar y descartar.
-          text: Roba 1 carta, más 1 carta por cada ficha de Extorsión bocarriba sobre el mapa. Después, si tienes más de 5 cartas en la mano, descarta cartas a tu elección hasta tener solo 5.
+        - name: Agotarse.
+          text: Puedes llevar a cabo una acción de las indicadas en tu Día si decides no robar cartas durante la Noche.
+        - name: Robar.
+          text: Roba una carta más una carta adicional por cada ficha de extorsión bocarriba que haya sobre el mapa. Después, si tienes más de cinco cartas en tu mano, descarta a tu elección hasta quedarte con cinco.
 
-    - name: Referencia de fichas de Conspiración
+    - name: Guía de las Fichas de Plan
       children:
         - name: Bomba.
-          text: Al voltear y revelar una ficha de Bomba, retira todas las piezas enemigas del claro, y después retira la ficha de Bomba.
-        - name: Trampa.
-          text: Mientras una ficha de Trampa esté bocarriba, los enemigos no pueden colocar piezas en este claro, ni mover piezas desde este claro.
+          text: Cuando se voltee una ficha de bomba, retira todas las piezas enemigas de este claro, después retira la ficha de bomba _(obtén un punto de victoria por ficha o edificio retirado)_.
+        - name: Cepo.
+          text: Mientras haya una ficha de cepo bocarriba, las piezas enemigas no pueden colocarse en ese claro o moverse de él.
         - name: Extorsión.
-          text: Al voltear una ficha de Extorsión, quita una carta al azar de la mano de cada jugador que tenga al menos una pieza en dicho claro. Por cada ficha de Extorsión que haya bocarriba, robarás una carta extra en tu Noche.
+          text: Cuando se voltee una ficha de extorsión, toma una carta al azar de cada jugador enemigo que tenga al menos una pieza de facción en ese claro. Mientras una ficha de extorsión esté bocarriba, robas una carta adicional en tu Noche.
         - name: Asalto.
-          text: Cuando una ficha de Asalto sea retirada _(independientemente de si estaba bocarriba o bocabajo)_, coloca un guerrero en cada claro adyacente al claro en que estaba situada la ficha de Asalto _(ignora este efecto si a ficha fue retirada por Exposición)_
+          text: Cuando se retire una ficha de asalto _(ya sea bocarriba o bocabajo)_, coloca un guerrero en cada claro adyacente al claro del que se retiró el asalto _(ignora este efecto si el asalto se retira por Exposición)_.
 
 - name: Variantes y Vagabundos extra
   color: "#000000"

--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -92,33 +92,33 @@
 - name: Victoria
   color: "#000000"
   children:
-    - name: Cómo ganar
-      pretext: La primera persona en alcanzar 30 puntos de victoria gana inmediatamente la partida. Si varias personas alcanzan 30 puntos de forma simultánea, quien esté jugando su turno actual será el ganador o ganadora.
+    - name: Condición de Victoria
+      pretext: El primer jugador en alcanzar 30 puntos de victoria gana inmediatamente el juego. Si más de un jugador llega a 30 o más puntos de victoria simultáneamente, el jugador cuyo turno se esté jugando gana.
 
-    - name: Obtener puntos de victoria
-      pretext: Cada facción tiene sus formas de obtener puntos de victoria, pero todas las facciones pueden obtener puntos de victoria de las formas siguientes.
+    - name: Obtener Puntos de Victoria
+      pretext: Cada facción tiene una forma única de obtener puntos de victoria, pero cualquier facción puede obtener puntos de victoria de las formas siguientes.
       children:
         - name: Retirar Edificios y Fichas.
-          text: Por cada Edificio o Ficha que retires, obtienes 1 punto de victoria.
+          text: Cuando retires un edificio o ficha enemiga, obtienes un punto de victoria.
         - name: Fabricar Objetos.
-          text: Al fabricar un objeto (`rule:4.1`), obtienes los puntos de victoria indicados en la carta. `faction:eyrie:7.2.3`
+          text: Cuando fabriques un objeto (`rule:4.1`), obtienes el número de puntos de victoria indicado en la carta. `faction:eyrie:7.2.3` `faction:warlord:14.2.3`
 
     - name: Cartas de Dominancia
-      pretext: El mazo contiene 4 cartas de Dominancia, que permiten obtener la victoria sin al alcanzar los 30 puntos de victoria si cumples su condición.
+      pretext: El mazo contiene cuatro cartas de dominancia, que te permiten obtener ganar la partida sin llegar a 30 puntos de victoria.
       children:
-        - name: Activación.
-          text: Durante tu Día, si tienes al menos 10 puntos de victoria, puedes **activar** una carta de Dominancia de tu mano, colocándola en tu área de juego. Si lo haces, retira tu marcador de puntos de victoria del tablero; ya no obtendrás puntos de victoria. `faction:vagabond:9.2.8`
+        - name: Activar.
+          text: Durante tu Día, si tienes al menos 10 puntos de victoria, puedes **activar** una carta de dominancia que esté en tu mano y colocarla en tu zona de juego. Quita tu marcador de puntuación del contador de puntuación. Ya no puedes obtener más puntos de victoria. `faction:vagabond:9.2.8`
           subchildren:
             - name: Dominancia de Ratón, Conejo o Zorro.
-              text: Ganas la partida inmediatamente si, al inicio de tu Alba, gobiernas los tres claros del palo correspondiente a la carta de Dominancia.
+              text: Ganas inmediatamente la partida si, al comienzo de tu Alba, gobiernas tres claros del palo correspondiente a la carta de dominancia activada.
             - name: Dominancia de Ave.
-              text: Ganas la partida inmediatamente si, al inicio de tu Alba, gobiernas dos claros de esquinas opuestas del tablero. _(Solo hay 4 esquinas; no valen todos los claros opuestos de los bordes)_.
-        - name: Cartas de Dominancia activadas.
-          text: Una carta de Dominancia activada no cuenta a efectos de tu límite de cartas en mano ni puede ser retirada de la partida. Tampoco se puede sustituir una la carta de Dominancia activada por otra diferente.
-        - name: Gastar por el palo.
-          text: Una carta de Dominancia no activada puede ser gastada por su palo, como cualquier otra carta normal. No obstante, al descartarse, esta no se coloca sobre la pila de descarte; en lugar de ello, debe colocarse junto al tablero para indicar que está **disponible** para ser reclamada. `faction:cult:10.4.2`        
-        - name: Reclamar una carta de Dominancia disponible.
-          text: Durante tu Día, puedes **reclamar** una carta de Dominancia a tu mano gastando para ello una carta del mismo palo.
+              text: Ganas inmediatamente la partida si, al comienzo de tu Alba, gobiernas dos claros en esquinas opuestas.
+        - name: Cartas activadas.
+          text: Una carta de dominancia activada no cuenta para tu límite de mano, y no puede retirarse del juego. No puedes sustituir una carta de dominancia activada por otra diferente.
+        - name: Usar Cartas de Dominancia.
+          text: Una carta de dominancia puede gastar se por su palo. Cuando una carta de dominancia fuese a ser colocada en la pila de descartes, en vez de ahí se sitúa junto al tablero para mostrar que está **disponible** para ser tomada. `faction:cult:10.4.2`
+        - name: Tomar Cartas Disponibles.
+          text: Durante tu Día, puedes tomar cualquier carta de dominancia disponible y ponerla en tu mando gastando una carta del palo correspondiente. Debes gastar una carta de ave para tomar la carta de dominancia de ave.
 
 - name: Acciones Clave
   color: "#000000"

--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -1,4 +1,5 @@
-
+# https://blog.pixelfreestudio.com/how-to-use-forks-in-github-for-collaborative-development/
+# https://github.com/icorreafalconi/root
 - name: Reglas de Oro
   color: "#000000"
   pretext: Este capítulo muestra respuestas a preguntas técnicas y concretas. No es necesario que lo leas la primera cez que aprendes el juego.
@@ -213,7 +214,7 @@
         - name: "Paso 1: Juntar Guerreros y Madera."
           text: Forma la reserva de guerreros (25) y fichas de madera (8).
         - name: "Paso 2: Colocar La Fortaleza."
-          text: Coloca la ficha de la fortaleza en un claro de una esquina a tu elección. Este es tu claro inicial.
+          text: Coloca la ficha de la fortaleza en un claro de una esquina a tu elección. Éste es tu claro inicial.
         - name: "Paso 3: Guarnición."
           text: Coloca un guerrero en cada claro excepto en el claro que está en la esquina diagonalmente opuesta al claro de la ficha de fortaleza.
         - name: "Paso 4: Colocar los Edificios Iniciales."
@@ -253,91 +254,91 @@
   icon: eyrie
   children:
     - name: Resumen
-      pretext: El Nido de Águilas aspira a restaurar la antigua gloria de su estirpe en el Bosque retomando el control de los claros del Bosque. Durante su Noche, el Nido de Águilas puntuará en función de cuántos **nidos** tenga en el mapa. Cuanto mayor sea su presencia en el Bosque, mayores serán sus ganancias. No obstante, el Nido está sujeto a su bound by their **Decreto**, un conjunto de acciones obligatorias en constante aumento prometidas por su **Líder**. Cada turno, el Nido debe realizar todas las acciones de su Decreto, o entrará en **Caos**.
+      pretext: Las Dinastías del Nido de Águilas desean restaurar su antiguamente digna estirpe a su gloria pasada retomando control de los claros del Bosque. Durante la Noche, el Nido de Águilas obtiene puntos de victoria en función del número de **nidos** que tiene en el mapa. Cuanto más nidos haya colocado, mayores son sus ganancias. Sin embargo, el Nido está atado a su **Decreto**, un conjunto siempre creciente de acciones obligatorias que han sido prometidas por su **líder**. Cada turno debe llevar a cabo todas las acciones de su Decreto, o caerá en el **caos**.
 
     - name: Reglas y Habilidades de Facción
       children:
         - name: Fabricar.
-          text: El Nido de Águilas fabrica antes de resolver el Decreto durante el día mediante la activación de nidos.
+          text: El Nido fabrica antes de resolver el Decreto durante el Día, activando nidos.
         - name: Señores del Bosque.
-          text:  El Nido de Águilas gobierna en los claros en caso de empate por número de guerreros y edificios. No gobierna sobre claros vacíos. `faction:cult:10.2.4`
-        - name: Desdén por el comercio.
-          text: Cuando el Nido de Águilas fabrica un objeto, ignora los puntos de victoria que marca la carta, y solo obtiene un punto en su lugar.
+          text: El Nido gobierna en un claro cuando está empatado a mayor número de guerreros y edificios en él, y tiene al menos una pieza de facción del Nido en él. `faction:cult:10.2.4`
+        - name: Desdén por el Comercio.
+          text: Cuando el Nido fabrique un objeto, ignora los puntos de victoria indicados, solo obtiene 1 punto de victoria en su lugar. _(Sí pueden obtener puntos adicionales por efectos de fabricación como en Maestros Grabadores o la Forja Legendaria)_.
 
-    - name: Preparación Individual
+    - name: Preparación
       children:
-        - name: "Paso 1: Guerreros."
-          text: Forma una reserva con tus 20 guerreros.
-        - name: "Paso 2: Nido y Guerreros iniciales."
-          text: Coloca 1 nido y 6 guerreros en el claro de la esquina diametralmente opuesta al claro de la esquina en que esté situada la Fortaleza del Marquesado. Si el Marquesado no está en juego, coloca dichas piezas en un claro de la esquina que elijas.
-        - name: "Paso 3: Líder."
-          text: Elige 1 de las 4 cartas de Líder del Nido y colócala sobre el espacio indicado de tu tablero de facción. Deja el resto de Líderes junto al tablero.
-        - name: "Paso 4: Asignar Visires."
-          text: Coloca tus 2 cartas de Visir Leal, de forma que se vea su palo, en las columnas de tu Decreto que especifica tu Líder.
-        - name: "Paso 5: Contador de Nidos."
-          text: Coloca tus 6 nidos restantes sobre el contador de Nidos del tablero, colocando 1 por casilla de derecha a izquierda _(el primer espacio quedará descubierto)_.
+        - name: "Paso 1: Juntar Guerreros."
+          text: Forma la reserva de guerreros (20).
+        - name: "Paso 2: Colocar Nido y Guerreros Iniciales."
+          text: Coloca 1 nido y 6 guerreros en un claro de una esquina que no sea el claro inicial de otro jugador y, si es posible, que sea diagonalmente opuesto a un claro inicial. Éste es tu claro inicial. _(Esto se ha actualizado con respecto a ediciones anteriores por flexibilidad)_.
+        - name: "Paso 3: Escoger Líder."
+          text: Elige 1 de las 4 cartas de líder y colócala en tu espacio de carta de líder. Deja el resto de líderes bocarriba en tu área de juego.
+        - name: "Paso 4: Colocar Visires."
+          text: Coloca tus 2 cartas de Visir Leal, mostrando su palo, en las columnas de Decreto de tu tablero según marque tu líder.
+        - name: "Paso 5: Rellenar Contador."
+          text: Coloca tus 6 nidos restantes en tu contador de nidos, de derecha a izquierda.
 
     - name: Alba
-      pretext: Tu Alba tiene 3 pasos en el siguiente orden. 
+      pretext: Tu Alba tiene tres pasos en el siguiente orden. 
       children:
-        - name: Órdenes de emergencia.
+        - name: Órdenes de Emergencia.
           text: Si no tienes cartas en tu mano, roba una carta.
         - name: Ampliar el Decreto.
-          text: Debes añadir 1 o 2 cartas de tu mano al Decreto, pero solo una de ellas puede ser una carta de ave. Puedes colocar cada carta en la columna que desees, y no hay límite de cartas por columna.
-        - name: Un nuevo nido.
-          text: Si no tienes nidos sobre el mapa, coloca 1 nido y 3 guerreros en el claro donde haya menos guerreros y puedas colocar estas piezas.
+          text: Debes añadir una o dos cartas al Decreto, pero solo una dichas cartas puede ser una carta de ave. Puedes colocar cada carta en cualquier columna, y cada columna puede contener cualquier número de cartas.
+        - name: Un Nuevo Nido.
+          text: Si no tienes nidos sobre el mapa, coloca un nido y tres guerreros en el claro que tenga menos guerreros, y que pueda albergar dichas piezas.
 
     - name: Día
-      pretext: Tu Día tiene 2 pasos en el siguiente orden.
+      pretext: Tu Día tiene dos pasos en el siguiente orden.
       children:
         - name: Fabricar.
-          text: Puedes activar Nidos para fabricar cartas de tu mano.
+          text: Puedes activar nidos para fabricar cartas de tu mano.
         - name: Resolver el Decreto.
-          text: Debes resolver completamente tu Decreto, comenzando por la primera columna de la izquierda, resolverla, y después pasar a la siguiente. En cada columna debes resolver todas las cartas, pero puedes hacerlo en cualquier orden. Por cada carta que haya, debes realizar la acción indicada en su columna tal y como se indica a continuación; si no puedes realizar o resolver completamente dicha acción, entras en Caos (`rule:7.7`).
+          text: Debes resolver el Decreto, empezando por la columna de más a la izquierda y avanzando hacia la derecha. En cada columna debes resolver todas las cartas, en cualquier orden. Por cada carta, debes llevar a cabo la acción de esa columna, como sigue. Si no puedes llevar a cabo una de esas acciones, caes inmediatamente en el caos (`rule:7.7`).
           subchildren:
             - name: Reclutar.
-              text: Coloca un guerrero en un claro en que haya un nido cuyo palo coincida con el palo de la carta.
+              text: Coloca un guerrero en un claro que tenga nido y sea correspondiente a la carta.
             - name: Mover.
-              text: Mueve desde un claro cuyo palo coincida con el palo de la carta _(debes mover al menos un guerrero)_.
+              text: Mueve desde cualquier claro correspondiente a la carta. _(Debes mover al menos un guerrero)_.
             - name: Batallar.
-              text: Inicia una batalla en un claro cuyo palo coincida con el palo de la carta.
+              text: Inicia una batalla en un claro correspondiente a la carta.
             - name: Construir.
-              text: Coloca un nido sobre cualquier claro en que gobiernes cuyo palo coincida con el palo de la carta.
+              text: Coloca un nido en un claro que gobiernes, que no tenga nido y sea correspondiente a la carta.
 
     - name: Noche
-      pretext: Tu Noche tiene 2 pasos en el siguiente orden.
+      pretext: Tu Noche tiene dos pasos en el siguiente orden.
       children:
-        - name: Puntuar nidos.
-          text: Suma los puntos indicados sobre espacio vacío más a la derecha de tu contador de nidos.
-        - name: Robar y descartar.
-          text: Roba 1 carta, más 1 por cada icono de robar carta descubierto sobre tu tablero de facción. Después, si tienes más de 5 cartas en tu mano, descarta cartas a tu elección hasta quedarte con solo 5.
+        - name: Puntúa.
+          text: Obtén los puntos de victoria indicados en el espacio vacío más a la derecha de tu contador de nidos.
+        - name: Robar y Descartar.
+          text: Roba una carta, más una carta adicional por cada símbolo de robo adicional descubierto. Entonces, si tienes más de cinco cartas en tu mano, descarta cartas a tu elección hasta quedarte con cinco.
 
     - name: Caos
-      pretext: Si no puedes resolver completamente una acción de tu Decreto por cualquier motivo, entras en Caos, y debes seguir los pasos indicados.
+      pretext: Si no puedes llevar a cabo al completo una de las acciones del Decreto (`rule:7.5.2`) por cualquier motivo, caes en el caos. Debes proceder en el siguiente orden.
       children:
-        - name: "Paso 1: Humillación."
-          text: Pierdes 1 punto de victoria por carta de ave _(contando también los Visires Leales)_ en tu Decreto.
+        - name: "Paso 1: Humilla."
+          text: Pierdes un punto de victoria por cada carta de ave _(Visires Leales incluidos)_ en tu Decreto.
         - name: "Paso 2: Purga."
-          text: Descarta todas las cartas de tu Decreto excepto los Visires Leales.
-        - name: "Paso 3: Deponer Líder."
-          text: Descarta bocabajo tu carta de Líder actual y déjala apartada, sin mezclarla con el resto de líderes no depuestos. Elige un nuevo líder de entre los restantes y colócalo bocarriba en el espacio de tu tablero de facción. Coloca los Visires Leales en las columnas que indica tu nueva carta de Líder.
+          text: Descarta todas las cartas en el Decreto excepto tus Visires Leales.
+        - name: "Paso 3: Depón."
+          text: Dale la vuelta a tu carta de líder actual y déjala a un lado. Elige un nuevo líder de los que están bocarriba y colócalo en tu tablero de facción. Coloca tus Visires Leales en los espacios de Decreto según marque tu nuevo líder.
           subchildren:
             - name: Nueva Nidada.
-              text: En caso que debas elegir un nuevo líder y no quede ninguna carta disponible bocarriba (no depuesta) colócalas todas bocarriba nuevamente.
-        - name: "Paso 4: Descansar."
-          text: Acaba tu día y procede a la Noche.
+              text: Si debes elegir un líder nuevo pero no queda ninguno bocarriba, dale la vuelta a todos.
+        - name: "Paso 4: Descansa."
+          text: Termina tu Día. Pasa a la Noche.
 
-    - name: Referencia de Líderes
-      pretext: El Nido de Águilas tiene 4 cartas de Líder, detalladas a continuación.
+    - name: Guía de Líderes
+      pretext: El Nido tiene cuatro cartas de líder, como sigue.
       children:
         - name: Constructor.
-          text: Tus Visires Leales empiezan en Reclutar y Mover. Cuando fabriques, ignora tu rasgo de facción Desdén por el Comercio (`rule:7.2.3`).
+          text: Los Visires Leales empiezan en Reclutar y Mover. Cuando fabriques, ignora tu habilidad especial Desdén por el Comercio (`rule:7.2.3`).
         - name: Carismático.
-          text: Tus Visires Leales empiezan en Reclutar y Batallar. Cuando realices la acción de reclutar, debes colocar 2 guerreros en lugar de uno.
+          text: Los Visires Leales empiezan en Reclutar y Batallar. Cuando reclutes, debes colocar dos guerreros en vez de uno.
         - name: Comandante.
-          text: Tus Visires Leales empiezan en Mover y Batallar. Como atacante en batalla, inflinges un impacto adicional.
+          text: Los Visires Leales empiezan en Mover y Batallar. Como atacante en batalla, das un golpe adicional.
         - name: Déspota.
-          text: Tus Visires Leales empiezan en Mover y Construir. Cuando retiras al menos un edificio o ficha enemiga en batalla, obtienes un punto de victoria extra _(1 solo punto por batalla, independientemente de la cantidad de fichas que retires)_.
+          text: Los Visires Leales empiezan en Mover y Construir. Cuando retires al menos un edificio o ficha enemiga en batalla, obtienes un punto de victoria extra _(dos en total `rule:3.2.1`)_.
 
 - name: La Alianza
   color: "#68b653"

--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -912,6 +912,100 @@
         - name: Asalto.
           text: Cuando se retire una ficha de asalto _(ya sea bocarriba o bocabajo)_, coloca un guerrero en cada claro adyacente al claro del que se retiró el asalto _(ignora este efecto si el asalto se retira por Exposición)_.
 
+- name: El Señor de los Cientos
+  color: "#e11b3f"
+  icon: warlord
+  children:
+    - name: Resumen
+      pretext: El Señor de los Cientos no soporta necedades y no permite discrepancias. Durante su Noe, obtiene puntos en función del grado de **opresión** al que somete a sus enemigos. Cuando más claros gobierne con piezas de los Cientos y sin piezas enemigas _(ni guerreros, ni edificios, ¡nada!) más puntos obtiene. Para aumentar su poder y captar guerreros, los Cientos deben ganar objetos y añadirlos a su creciente **Botín**. Liderando a los Cientos está el **Señor de la Guerra**, un guerrero demagogo cuyo inestable **estado de ánimo** le da una habilidad durante el turno. El señor de la guerra está obsesionado con el botín, así que a medida que los Cientos consiguen más objetos, él tendrá menos estados de ánimo entre los que escoger. Declarándose a ellos mismos como la verdadera voz del Bosque, los Cientos pueden instigar **turbas**, que destruirán fichas y edificios enemigos, y saquearán los objetos de las ruinas.
+
+    - name: Reglas y Habilidades de Facción
+      children:
+        - name: Fabricar.
+          text: Los Cientos fabrican durante el Día activando bastiones.
+        - name: El Señor de la Guerra.
+          text: Los Cientos tienen una pieza llamada señor de la guerra. El señor de la guerra es un guerrero que no puede ser retirado sin ser en batalla, movido si no es en el turno de los Cientos o colocado de otra forma que no sea mediante la preparación (`rule:14.3.2`) o con la acción Ungir (`rule:14.4.3`). _(Es inmune a efectos de Retirada Total, a la ballesta del Vagabundo y a acciones forzadas)_.
+        - name: Indiferencia por el Comercio.
+          text: Cuando los Cientos fabrican un objecto, pueden tomar el objeto pero no obtienen ninguno de los puntos indicados, o pueden retirar ese objeto de la partida y obtener los puntos indicados. _(Sí pueden obtener puntos adicionales por efectos de fabricación como en Maestros Grabadores o la Forja Legendaria)_.
+        - name: El Botín.
+          text: En vez de una zona para objetos fabricados, los Cientos tienen el Botín. Consta de dos contadores, Mando y Arrojo. El contador de Mando puede contener `item:boot`, `item:sack` y `item:coin`. El de Arrojo `item:hammer`, `item:tea`, `item:sword` y `item:crossbow`.
+          subchildren:
+            - name: Conseguir Objetos.
+              text: Cuando los Cientos consiguen un objeto, lo colocan en el espacio vacío más a la izquierda del contador de Mando o Arrojo según el tipo de objeto; si no hay un espacio vacío, deben retirar de la partida el objeto obtenido o cualquier objeto del contador _(reemplazándolo por el obtenido)_, y obtienen un punto de victoria.
+            - name: Mando y Arrojo.
+              text: El número de objetos en los contadores de Mando y Arrojo determinan el valor de Mando y Arrojo, que afecta a varios aspectos de sus reglas. Sin objetos, tienen 1 de Mando y Arrojo; con uno o dos objetos, tienen 2; con tres objetos, tienen 3; con cuatro objetos, tienen 4.
+        - name: Saqueadores.
+          text: Al comienzo de una batalla como atacantes, los Cientos pueden declarar que quieren saquear al defensor, siempre que el defensor tenga un objeto en su zona de objetos fabricados. _(No pueden saquear al Vagabundo)_. Si declaran que quieren saquear, los Cientos no infligirán golpes con la tirada de dados _(el defensor sí da golpes con su tirada, y los Cientos sí pueden causar golpes adicionales, como con su estado de ánimo Iracundo)_. Si al final de la batalla los Cientos gobiernan el claro de batalla, toman un objeto de la zona de objetos fabricados del defensor.
+
+    - name: Preparación
+      children:
+        - name: "Paso 1: Juntar Guerreros y Bastiones"
+          text: Forma la reserva de guerreros (20), el señor de la guerra y bastiones (6).
+        - name: "Paso 2: Guarnición"
+          text: Coloca tu señor de la guerra, cuatro guerreros y un bastión en un claro de una esquina que no sea el claro inicial de otro jugador y, si es posible, que sea diagonalmente opuesto a un claro inicial.
+        - name: "Paso 3: Colocar Objetos"
+          text: Coloca los cuatro objetos "R" aleatoriamente bajo las ruinas, a menos que ya se haya hecho.
+        - name: "Paso 4: Volverse Obstinado"
+          text: Coloca tu carta de estado de ánimo Obstinado en el espacio de Carta de Estado de Ánimo.
+          
+    - name: Alba
+      pretext: Tu Alba tiene cuatro pasos en el siguiente orden.
+      children:
+        - name: Arrasar.
+          text: En cada claro con una ficha de turba, retira todas las fichas y edificios enemigos _(obtén un punto de victoria por cada una. Sin efecto sobre guerreros, peones, etc.)_, toma un objeto de la ruina del claro, si la hay, y retira la ruina si era su último objeto. Tras resolver todas las turbas debes lanzar el dado de turba una vez y colocar una ficha de turba en un claro correspondiente que no tenga una ficha de turba pero que sea adyacente a un claro con ficha de turba. _(Si no hay un claro que cumpla esto, no coloques la ficha de turba)_.
+        - name: Reclutar.
+          text: Coloca tantos guerreros como valor de Arrojo en el claro de tu señor de la guerra. Luego, coloca guerreros en cada claro con bastiones, un guerrero por cada bastión en él.
+        - name: Ungir.
+          text: Si tu señor de la guerra no está en el mapa, debes reemplazar un guerrero cualquiera de los Cientos por el señor de la guerra. Si no puedes, debes poner a tu señor de la guerra en un claro cualquiera.
+        - name: Escoger Estado de Ánimo.
+          text: Debes reemplazar la carta de estado de ánimo en el espacio de tu tablero de facción por una carta diferente de estado de ánimo que no muestre un objeto que esté en tu botín. Si eres Fastuoso y no puedes escoger una nueva carta, permaneces Fastuoso.
+
+    - name: Día
+      pretext: Tu Día tiene tres pasos en el siguiente orden.
+      children:
+        - name: Fabricar.
+          text: Puedes activar bastiones para fabricar cartas.
+        - name: Comandar a los Cientos.
+          text: Puedes realizar las siguientes acciones, en cualquier orden y hasta un número de veces igual a tu valor de Mando.
+          subchildren:
+            - name: Mover.
+              text: Haz un movimiento.
+            - name: Batallar.
+              text: Inicia una batalla.
+            - name: Construir.
+              text: Gasta una carta para colocar un bastión en un claro correspondiente que gobiernes.
+        - name: Avance del señor de la guerra.
+          text: Puedes realizar esta acción hasta un número de veces igual a tu valor de Arrojo. Puedes mover a tu señor de la guerra con cualquier cantidad de guerreros de los Cientos y, después, hayas movido o no, puedes iniciar una batalla en el claro de tu señor de la guerra.
+
+    - name: Noche
+      pretext: Tu Noche tiene tres pasos en el siguiente orden.
+      children:
+        - name: Instigar.
+          text: Cualquier número de veces, puedes gastar una carta para colocar una ficha de turba en un claro correspondiente que no tenga ya una ficha de turba pero en el que haya al menos un guerrero de los Cientos _(lo que incluye a tu señor de la guerra)_.
+        - name: Oprimir.
+          text: Obtienes puntos de victoria según el número de claros que gobiernes que tengan al menos una pieza de los Cientos y ninguna pieza enemiga. Por uno o dos claros, obtén un punto; por tres o cuatro claros, obtén dos puntos; por cinco claros, obtén tres puntos; por seis o más claros, obtén cuatro puntos.
+        - name: Robar y Descartar.
+          text: Roba una carta. Si tienes más de cinco cartas en tu mano, descarta cartas a tu elección hasta quedarte con cinco.
+
+    - name: Estados de Ánimo
+      children:
+        - name: Encarnizado (`item:hammer`).
+          text: En batalla en el claro de tu señor de la guerra, antes de lanzar los dados puedes retirar cualquier cantidad de fichas de turba del claro de tu señor de la guerra y de cualquier claro adyacente a él. Coloca tantos guerreros en el claro de tu señor de la guerra como fichas de turba hayas retirado.
+        - name: Grandilocuente (`item:tea`).
+          text: Este turno, realiza el paso de Avance del señor de la guerra (`rule:14.5.3`) y el paso de Comandar a los Cientos (`rule:14.5.2`) en orden inverso. _(Primero Avanzas al señor de la guerra, después Comandas a los Cientos.)_
+        - name: Exultante (`item:boot`).
+          text: Cuando realices la acción de Instigar en el claro de tu señor de la guerra, tras colocar la ficha de turba de la acción, puedes _(hasta cuatro veces)_ lanzar el dado de turba y colocar una ficha de turba en un claro correspondiente que no tenga una ficha de turba pero que sea adyacente a un claro con ficha de turba.
+        - name: Fastuoso (Sin Objeto).
+          text: Al final de tu Alba, puedes retirar de la partida cualquier número de objetos en tu Botín. Por cada objeto que retires, coloca dos guerreros en el claro de tu señor de la guerra. Al terminar, reubica los objetos en tu Botín de modo que sus contadores se cubran de izquierda a derecha.
+        - name: Implacable (`item:sack`).
+          text: Cada vez que realices una acción de Avance del señor de la guerra en la que muevas e inicies batalla, después, como parte de esa misma acción, puedes mover de nuevo a tu señor de la guerra con cualquier número de guerreros de los Cientos o batallar de nuevo en el claro de tu señor de la guerra.
+        - name: Pendenciero (`item:coin`).
+          text: En tu Noche, roba una carta más (`rule:14.6.3`). Si el claro de tu señor de la guerra tiene tres o más piezas enemigas _(incluso combinando piezas de distintos enemigos)_, roba dos cartas más en vez de una.
+        - name: Obstinado (`item:crossbow`).
+          text: En una batalla en el claro de tu señor de la guerra ignoras el primer golpe que recibes. _(Esto no se acumula con otras habilidades que te permiten ignorar el primer golpe que recibes)_.
+        - name: Iracundo (`item:sword`).
+          text: Como atacante en una batalla en el claro de tu señor de la guerra das un golpe adicional.
+
 - name: Variantes y Vagabundos extra
   color: "#000000"
   children:

--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -799,7 +799,7 @@
             - name: Excavar.
               text: Gasta una carta para colocar una ficha de túnel en un claro correspondiente que no tenga una ficha de túnel. Entonces mueve hasta cuatro guerreros desde la madriguera a ese claro. _(Si los tres túneles están sobre el tablero, puedes retirar uno antes)_.
         - name: Parlamento.
-          text: Puedes llevar a cabo la acción de cada uno de los minsitros convencidos, una vez cada una en cualquier orden.
+          text: Puedes llevar a cabo la acción de cada uno de los ministros convencidos, una vez cada una en cualquier orden.
           subchildren:
             - name: Capatopo.
               text: Revela cualquier carta para colocar una ciudadela o mercado en cualquier claro _(correspondiente o no)_ que gobiernes.
@@ -814,7 +814,7 @@
             - name: Alcalde.
               text: Lleva a cabo la acción de cualquier noble o escudero convencidos.
             - name: Duquesa del Lodo.
-              text: Obtén dos puntos de victoria si los trestúneles están sobre el mapa.
+              text: Obtén dos puntos de victoria si los tres túneles están sobre el mapa.
             - name: Barón de la Tierra.
               text: Obtén un punto de victoria por cada mercado que haya sobre el mapa.
             - name: Conde de la Piedra.
@@ -833,7 +833,7 @@
       pretext: Tu Noche tiene tres pasos en el siguiente orden.
       children:
         - name: Descartar y Devolver Cartas Reveladas.
-          text: Descarta cualquier cantidad de cartas de ave que hayas revelado este turno, despuṕes devuelve todas las demás cartas reveladas a tu mano.
+          text: Descarta cualquier cantidad de cartas de ave que hayas revelado este turno, después devuelve todas las demás cartas reveladas a tu mano.
         - name: Fabricar.
           text: Puedes fabricar cartas de tu mano activando ciudadelas y mercados _(son idénticos a efectos de fabricación)_.
         - name: Robar y Descartar.
@@ -854,7 +854,7 @@
           text: Los Córvidos tienen ocho fichas de plan, dos de cada tipo.
           subchildren:
             - name: Sentido de la Ficha.
-              text: Mientras que estén en la reserva de los Córvidos, las fichas de plan están bocabajo _(pluma)_. Mientras está en el mapa, una ficha puede estar bocarriba _(ícono único)_ o bocabajo. Los córvidos pueden inspeccionar una ficha de plan que esté bocabajo en cualquier momento.
+              text: Mientras que estén en la reserva de los Córvidos, las fichas de plan están bocabajo _(pluma)_. Mientras está en el mapa, una ficha puede estar bocarriba _(ícono único)_ o bocabajo. Los Córvidos pueden inspeccionar una ficha de plan que esté bocabajo en cualquier momento.
             - name: Límites de Colocación.
               text: Cada claro sólo puede tener una única ficha de plan.
         - name: Grácil.
@@ -864,7 +864,7 @@
         - name: Agentes Infiltrados.
           text: Como defensor en la batalla, si los Córvidos tienen una ficha de plan bocabajo _(incluso si están indefensos)_ en el claro de batalla, dan un golpe adicional.
 
-    - name: Preparación Individual
+    - name: Preparación
       children:
         - name: "Paso 1: Juntar Guerreros y Planes."
           text: Forma la reserva de guerreros (15) y las fichas de planes bocabajo (8).
@@ -887,7 +887,7 @@
         - name: Mover.
           text: Haz un movimiento.
         - name: Planear.
-          text: retira un guerrero Córvido, más otro guerrero Córvido por cada plan que ya hayas colocado este turno, de un claro que no tenga ficha de plan para colocar una ficha de plan bocabajo en él.
+          text: Retira un guerrero Córvido, más otro guerrero Córvido por cada plan que ya hayas colocado este turno, de un claro que no tenga ficha de plan para colocar una ficha de plan bocabajo en él.
         - name: Batallar.
           text: Inicia una batalla.
         - name: Trucar.

--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -1235,3 +1235,41 @@
               text: Empieza con `item:coin`, `item:torch`, `item:sword`, `item:crossbow`.
             - name: "Acción Especial: Vuelo sin motor"
               text: Agota una `item:torch` para mover únicamente a tu peón de Vagabundo _(no otras piezas)_ a cualquier claro _(incluso Hostil)_ del mapa sin agotar ninguna `item:boot`.
+
+    - name: Secuaces
+      children:
+        - name: Conseguir y Perder Secuaces
+          subchildren:
+            - name: Conseguirlos de la Reserva.
+              text: Cuando el marcador de puntos de victoria de un jugador entre en la casilla con un marcador de secuaz, ese jugador toma el marcador de secuaz y lo coloca bajo la Noche en su tablero de facción _(como recordatorio)_. Al final de su turno, toma una carta cualquiera de secuaz de la reserva, hace una tirada de control (`rule:16.4.1.2`) y da la vuelta al marcador de secuaz.
+            - name: Tirada de Control.
+              text: Cuando un jugador consigue una carta de secuaz, lanza el dado de control y coloca tantos marcadores de control sobre la carta de secuaz como resultado haya obtenido a esa tirada. Si ese jugador es quien más puntos de victoria tiene, o está empatado con quien más tiene, cuenta solamente los símbolos dorados del dado; en cualquier otro caso cuenta todos los símbolos _(incluso si tiene activa una carta de dominancia)_.
+            - name: Conseguirlos de Otro Jugador.
+              text: Al final del turno de un jugador, el jugador debe retirar un marcador de control de cada uno de sus secuaces. Luego, debe entregar cada carta de secuaz que control que se haya quedado sin marcadores de control, junto con un marcador de secuaz, a cualquier otro jugador _(incluso al jugador con más puntos de victoria)_. Ese jugador coloca el marcador de secuaz bajo la Noche en su tablero de facción _(como recordatorio)_ y realiza una tirada de control inmediatamente (`rule:16.4.1.2`).
+        - name: Habilidades y Acciones
+          text: Los Secuaces tienen ciertas acciones y habilidades, indicadas por sus propios iconos. Las acciones y habilidades que comienzan con "**Controlador**:" las obtiene el controlador del secuaz.
+          subchildren:
+            - name: Acción Al Conseguir (`hireling:whenhired`).
+              text: Al tomar el control de un secuaz, el jugador que pasa a ser el controlador debe realizar esta acción.
+            - name: Habilidad (`hireling:ability`).
+              text: Esta habilidad está siempre activa o especifica cuándo sucede.
+            - name: Acción Al comienzo del Alba (`hireling:birdsong`).
+              text: Al comienzo de su Alba, el jugador que control aal secuaz debe o puede realizar esta acción, tal y como ella indique.
+            - name: Acción Una vez por Día (`hireling:daylight`).
+              text: Una vez en su Día, el jugador que controla al secuaz puede realizar esta acción.
+        - name: Reglas
+          subchildren:
+            - name: Gobernar.
+              text: El controlador de un secuaz trata las piezas de su secuaz como suyas sólo para gobernar _(El controlador podría gobernar un claro con únicamente piezas de secuaz)_. Los secuaces sin controlador pueden gobernar un claro como si fuesen jugadores (`rule:2.5`).
+            - name: Condición de Enemigo.
+              text: Un secuaz es un enemigo para todos los jugadores salvo para su controlador y para los jugadores en una coalición con su controlador.
+            - name: Piezas Independientes.
+              text: Las piezas de secuaces no son piezas de facción de su controlador. _(Por lo que el Ducado no puede contarlas como piezas para convencer, los Guardianes no pueden retirarlas para acampar, etc.)_.
+            - name: Acciones Independientes.
+              text: Las acciones de Mover o Batallar de un secuaz solamente permiten mover o batallar con piezas de ese secuaz y no pueden incluir las piezas de su controlador. Los secuaces no pueden realizar acciones de otras maneras _(como con las acciones de Mover de su controlador, con Órdenes Falsas o mediante la relación de Aliado con el Vagabundo)._
+            - name: Efectos Independientes.
+              text: Los secuaces no pueden usar las habilidades de su controlador, ni sus efectos persistentes fabricados ni sus cartas de emboscada. _(Por lo tanto, un secuaz no podrá usar Carpinteros de Ribera al mover, y los Salteadores de Caminos no podrían colocarse en un río. El controlador de un secuaz no puede jugar una carta de emboscada al batallar con un secuaz)_.
+            - name: Sin puntos al Retirar.
+              text: El controlador de un secuaz no obtiene puntos de victoria si sus secuaces retiran una pieza enemiga _(normalmente en batalla)_. _(Sin embargo, los jugadores sí pueden obtener puntos al retirar edificios y fichas pertenecientes a secuaces, incluso al ser el defensor contra un secuaz. Un jugador obtiene puntos de forma habitual si los Profetas del Cálido Sol fuerzan a las piezas de su facción a batallar)_.
+            - name: Cosas Raras.
+              text: Si mueves a un secuaz con el Transbordador, robas una carta. Si mueves a un guerrero secuaz a un claro con una ficha de simpatía de la Alianza o retiras una ficha de simpatía usando a un secuaz, se activa Indignación. _(Estos efectos se refieren al "jugador que mueve" o "al jugador que retira")_.

--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -1006,6 +1006,88 @@
         - name: Iracundo (`item:sword`).
           text: Como atacante en una batalla en el claro de tu señor de la guerra das un golpe adicional.
 
+- name: Los Guardianes de Hierro
+  color: "#8b8d90"
+  icon: keepers
+  children:
+    - name: Resumen
+      pretext: Los Guardianes de Hierro son una orden de devotos caballeros, que tiempo atrás fueron exiliados del Bosque, pero han regresado para recuperar las **reliquias** perdidas en conflictos del pasado. No obstante, que estas reliquias pertenezcan a los Guardianes o al Bosque, ya es otra cuestión. Para cumplir su misión, necesitarán desenterrar las reliquias de los bosques, llevarlas a un **puesto provisional** del mismo tipo, y, finalmente, recuperarlas. Cuando recuperen una reliquia, obtienen tantos puntos de victoria como el valor de la misma, de uno a tres, y además también obtienen dos puntos cada vez que completan un conjunto de tres tipos de reliquias _(figuras, tablas y joyas)_. Con el paso del tiempo, los Guardianes reunirán un **Séquito** de criaturas del Bosque, permitiéndoles realizar más acciones. Sin embargo, cada vez que desentierren o recuperen una reliquia, podrían perder la carta del Séquito que usaron para ello, por lo que necesitarán planear por adelantado y adoptar una gestión prudente del riesgo para tener éxito.
+
+    - name: Reglas y Habilidades de Facción
+      children:
+        - name: Reliquias.
+          text: "Buscan un total de doce fichas de reliquias de tres tipos: figuras, tablas y joyas. CAda tipo de reliquia consta de cuatro fichas. El anverso de la reliquia muestra su tipo, el reverso muestra un valor de 1, 2, 3 o 3."
+        - name: Puestos provisionales.
+          text: Tienen tres puestos provisionales. Cada puesto provisional muestra un tipo de reliquia en su anverso y otro tipo en su reverso.
+        - name: Fabricar.
+          text: Los Guardianes fabrican durante el Día activando puestos provisionales _(de cualquier tipo)_.
+        - name: Caballeros Devotos.
+          text: En batalla, si en el claro de batalla hay al menos una reliquia y un guerrero de los Guardianes, los Guardianes ignorar el primer golpe recibido _(ante una emboscada, ignoran un golpe de la emboscada, pero no los siguientes golpes)_. Al mover, los Guardianes pueden mover una reliquia con cada guerrero Guardián que se mueva.
+        - name: Trofeos Valiosos.
+          text: Cada vez que un enemigo retira una reliquia, la coloca bocarriba _(mostrando su valor)_ en cualquier bosque a su elección y obtiene un punto de victoria adicional _(dos en total)_.
+
+    - name: Preparación
+      children:
+        - name: "Paso 1: Colocar las Reliquias Iniciales"
+          text: Junta las doce fichas de reliquias y mézclalas bocabajo _(sin mostrar su valor)_. Coloca una aleatoriamente en cada bosque _(una forma de proceder podría ser que el jugador Guardián, tras mezclar las reliquias, las apile y que luego cualquier otro jugador corte esa pila y vaya dejando las reliquias del fondo de una en una en cada bosque)_.
+        - name: "Paso 2: Juntar Guerreros"
+          text: Forma la reserva de guerreros (15).
+        - name: "Paso 3: Colocar Guerreros"
+          text: Coloca cuatro guerreros en un claro de una esquina que no sea el claro inicial de otro jugador y, si es posible, que sea diagonalmente opuesto a un claro inicial. Después, coloca cuatro guerreros en un claro del borde del tablero que sea adyacente al claro anterior.
+        - name: "Paso 4: Colocar las demás Reliquias"
+          text: Coloca las restantes reliquias aleatoriamente, repartidas tan equitativamente como sea posible entre los bosques que no sean adyacentes a los claros con tus guerreros.
+        - name: "Paso 5: Colocar Seguidores Fieles"
+          text: Coloca una carta de Seguidor Fiel en cada espacio del Séquito de tu tablero de facción.
+        - name: "Paso 6: Reunir Puestos Provisionales"
+          text: Coloca tus tres edificios de puestos provisionales en sus correspondientes espacios sobre tu tablero de facción.
+
+    - name: Alba
+      pretext: Tu alba tiene tres pasos en el orden siguiente.
+      children:
+        - name: Acampar.
+          text: Una vez por claro, puedes reemplazar un guerrero Guardián por un puesto provisional. Si no tienes guerreros ni puestos provisionales en el mapa, en lugar de lo anterior, coloca un puesto provisional y un guerrero en cualquier claro del borde del tablero. En cualquier caso, al colocar el puesto provisional puedes hacerlo bocarriba o bocabajo, a tu elección.
+        - name: Levantar Campamento.
+          text: Una vez por claro, puedes reemplazar un puesto provisional por un guerrero Guardián.
+        - name: Reclutar.
+          text: Cualquier número de veces, puedes gastar una carta para colocar dos guerreros en un puesto provisional correspondiente.
+
+    - name: Día
+      pretext: Tu Día tiene dos pasos en el orden siguiente.
+      children:
+        - name: Fabricar.
+          text: Puedes fabricar cartas de tu mano activando puestos provisionales _(de cualquier tipo)_.
+        - name: Actuar con el Séquito.
+          text: Comenzando por la columna más a la izquierda del Séquito y yendo hacia la derecha, puedes realizar la  acción descrita en cada columna para cada carta en ella, en cualquier orden _(incluso ignorar alguna)_, del modo siguiente.
+          subchildren:
+            - name: Mover.
+              text: Haz un movimiento desde un claro correspondiente a la carta.
+            - name: Batallar y Desenterrar.
+              text: Escoge un claro correspondiente a la carta. Debes iniciar una batalla en él si hay alguna pieza enemiga allí. Después, si gobiernas ese claro y tienes al menos un guerrero Guardián en él, puedes desenterrar como sigue _(incluso si no hubo enemigo para batallar)_.
+              subchildren:
+                - name: "Paso 1: Mover y Voltear la Reliquia"
+                  text: Mueve cualquier reliquia de un bosque adyacente a ese claro. Voltea la reliquia de modo que su valor se muestre, si no lo está ya.
+                - name: "Paso 2: Comprobar Descarte"
+                  text: Cuenta el número de claros que gobiernas adyacentes al bosque en el que desenterraste la reliquia. Si ese número es menor que el valor de la reliquia, debes descartar la carta del Séquito usada para esta acción.
+            - name: Mover o Recuperar.
+              text: Escoge un claro correspondiente a la carta. Realiza un movimiento desde él o recupera una reliquia en él, según se indica a continuación.
+              subchildren:
+                - name: "Paso 1: Tomar Reliquia"
+                  text: Toma una reliquia en ese claro que sea del mismo tipo que el de un puesto provisional que esté en él. Colócala en el espacio de Reliquias vacío de ese tipo más a la izquierda en tu tablero de facción.
+                - name: "Paso 2: Obtener Puntos de Victoria"
+                  text: Obtén tantos puntos de victoria como el valor de la reliquia y, si completas una columna de reliquias, obtén dos puntos de victoria más.
+                - name: "Paso 3: Comprobar Descarte"
+                  text: "Cuenta el número de claros que gobiernas cuyo palo se corresponda con el del claro del cual estás recuperando la reliquia _(incluyendo a ese claro de ser el caso)_. Si ese número es menor que el valor de la reliquia recuperada, debes finalizar esta acción de Recuperar y descartar la carta del Séquito usada para realizarla. De no ser así, puedes volver al paso 1: Tomar Reliquia _(de ese mismo claro)_ o finalizar la acción de Recuperar."
+
+    - name: Noche
+      pretext: Tu Noche tiene tres pasos en el siguiente orden.
+      children:
+        - name: Vivir de la tierra
+          text: Debes retirar un guerrero Guardián de cada claro que tenga cuatro o más guerreros Guardianes.
+        - name: Reunir al Séquito.
+          text: "Escoge una opción: Puedes añadir cualquier número de cartas de tu mano a los espacios del Séquito, o bien, puedes cambiar a un espacio diferente una carta que ya esté en tu Séquito. Tu Séquito no puede contener más de diez cartas."
+        - name: Robar y Descartar .
+          text: Roba una carta, más una carta adicional por cada símbolo de robo adicional descubierto _(tantas como puestos provisionales sobre el mapa)_.
+
 - name: Variantes y Vagabundos extra
   color: "#000000"
   children:

--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -1149,46 +1149,37 @@
         - name: "Paso 10: Seleccionar las Manos Iniciales"
           text: Cada jugador escoge tres cartas para mantener en su mano y coloca las otras dos bocabajo en el mazo común. Cuando todos lo hayan hecho, barajad el mazo.
 
-    - name: Mapas
+    - name: Variantes de Mapas
       children:
         - name: Mapa de Invierno
           subchildren:
-            - name: Río Bravo.
-              text: El río divide bosques como si cada tramo del río que conecta dos claros fuese un camino.
-
+            - name: Río Revuelto.
+              text: El río divide los bosques _(como lo hacen los caminos impresos)_.
         - name: Mapa del Lago
           subchildren:
-            - name: Cambios en la preparación.
-              text: Coloca la pieza de la Barcaza en el claro de la esquina que es un claro costero, situado sobre la parte final del contador de puntos _(el claro inferior derecho si miras al tablero con el contador de puntos frente a ti)_.
-
+            - name: Modificaciones a la Preparación.
+              text: Coloca el Transbordador en el claro de la esquina que también es un claro costero.
             - name: El Lago.
-              text: "**El lago** está situado en el centro del mapa. El lago se trata como si hubiese ríos que conectan todos los claros costeros entre sí."
-
-            - name: Claros costeros.
-              text: Los claros que tocan el lago _(no separados de él por un bosque)_ son **claros costeros**.
-
-            - name: Bosques costeros.
-              text: Los bosques que tocan el lago son **bosques costeros**. Cada bosque costero es adyacente a sus dos bosques costeros próximos _(separados por un claro costero)_.
-
-            - name: La Barcaza.
-              text: Una vez por turno, un jugador que esté realizando un movimiento desde el claro costero donde esté situada la Barcaza puede mover a otro claro costero, moviendo la barcaza consigo. _(Se aplican las reglas de movimiento normales)_. Después de realizar este movimiento, dicho jugador roba una carta. La Barcaza no puede ser batallada ni retirada.
+              text: El **lago** está en el centro del mapa. El lago se trata como ríos que unen un claro costero con todos los demás claros costeros _(lo que permite Nadadores y Barcas)_. El lago divide a los bosques.
+            - name: Claros Costeros.
+              text: Los claros que tocan el lago (que no están separados por un bosque) son **claros costeros**.
+            - name: Bosques Costeros.
+              text: Los bosques que tocan el lago son **bosques costeros**. Cada bosque costero es adyacente a sus dos bosques costeros vecinos _(separados por un claro costero)_.
+            - name: El Transbordador.
+              text: "Una vez por turno, las piezas en un claro costero donde esté el Transbordador pueden mover a otro a otro claro costero, tratándolo como adyacente y moviendo al Transbordador con ellas _(se siguen las reglas de movimiento normal: Gobernar claros, Indignación, etc.)_. Tras mover, el jugador roba una carta. El transbordador no puede ser retirado ni puede batallarse contra él."
             
         - name: Mapa de la Montaña.
           subchildren:
-            - name: Cambios en la preparación.
-              text: Coloca las 6 losetas de camino bloqueado sobre los 6 caminos de color más oscuro con tierra excavada dibujada. Coloca la Torre en el claro central con dos torres dibujadas.
-
-            - name: Caminos bloqueados.
-              text: Los caminos cubiertos por losetas son **caminos bloqueados**. Los claros conectados por caminos bloqueados no son adyacentes. Los caminos bloqueados delimitan y dividen los bosques como si fueran caminos válidos _(por lo que el Vagabundo puede moverse a través de ellos)_.
-
-            - name: Despejar caminos bloqueados.
-              text: Una vez por turno durante el Día, un jugador puede gastar una carta para retirar una loseta de camino bloqueado del juego permanentemente y obtener un punto de victoria por ello. Para retirar la loseta, el jugador debe tener al menos una pieza en cualquiera de los dos claros que conecta dicho camino bloqueado.
-
-            - name: El Paso.
-              text: El claro de la Torre es **El Paso**. Al final de su Noche, si el jugador gobierna El Paso, dicho jugador obtiene 1 punto de victoria.
-
+            - name: Modificaciones a la Preparación.
+              text: Coloca los 6 marcadores de camino cerrado para cubrir los 6 caminos de un color más oscuro con terreno excavado. Coloca la Torre en el claro central que muestra dos torres.
+            - name: Caminos Cerrados.
+              text: Un camino cubierto con un marcador de camino cerrado es un **camino cerrado**. Los claros unidos por un camino cerrado no son adyacentes, y las piezas _(como los Salteadores de Caminos)_ no pueden colocarse en caminos cerrados. Los caminos cerrados delimitan y dividen los bosques como si fueran caminos _(por lo que el Vagabundo puede infiltrarse a través de ellos)_.
+            - name: Retirar Caminos Cerrados.
+              text: Una vez por turno en su Día, un jugador puede gastar una carta para retirar un marcador de camino cerrado de la partida y obtener un punto de victoria. Para retirarlo, el jugador debe tener al menos una pieza de facción en cualquiera de los claros que están conectados por ese marcador de camino cerrado.
+            - name: El Paso y la Torre.
+              text: El claro marcado con la pieza de la Torre es **el Paso**. Al final de la Noche de un jugador, si ese jugador gobierna el Paso, obtiene un punto de victoria.
             - name: Bosques.
-              text: Todas las zonas del mapa de montaña rodeadas por caminos y claros son bosques (`rule:2.2`), independientemente de la presencia o posición de los árboles en ellas.
+              text: Todas las áreas del mapa de montaña delimitadas por caminos y claros son bosques (`rule:2.2`), independientemente de que haya árboles impresos o no.
 
     - name: Vagabundos
       children:

--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -46,74 +46,48 @@
           plainName: Uso de Forzar.
           text: Algunos efectos te permiten **forzar** a un jugador o a sus piezas a actuar. Resuelve la situación del mismo modo en el que ese jugador lo haría _(siguiendo las reglas generales)_, teniendo en cuenta posibles efectos. _(Por ejemplo, si fuerzas al Nido a mover guerreros, se benefician de la regla Señores del Bosque)_.
 
-- name: Términos Clave y Conceptos de juego
+- name: Conceptos y Términos Clave
   color: "#000000"
+  pretext: Los términos se definen de forma rigurosa en el Glosario (`rule:16.6`).
   children:
-    - name: Cartas del mazo común.
-      pretext: "Cada carta del mazo común tiene un **palo**: ave, zorro, conejo o ratón. Muchos efectos de las Facciones exigen que gastes cartas según su palo. Además, la mayoría tiene un efecto que puedes obtener si **fabricas** dicha carta (`rule:4.1`)."
+    - name: Cartas
+      pretext: "Las cartas se roban de la parte superior del mazo común y se descartan a una pila de descartes común. Si en cualquier momento el mazo se queda sin cartas, baraja la pila de descartes inmediatamente para formar uno nuevo. Cada carta tiene un **palo**: Ave, zorro, conejo o ratón. La mayoría de cartas también tiene un efecto que puedes fabricar (`rule:4.1`)."
       children:
         - name: Las aves son comodín.
-          text: Puedes utilizar siempre una carta del palo de ave como si fuese una carta de otro palo _(zorro, conejo o ratón)_, incluso si debes gastar, tomar o dar múltiples cartas del mismo palo. `faction:cult:10.2.2`
+          text: Siempre puedes tratar una carta de ave como una carta de cualquier otro palo, incluso si debes gastar, tomar o dar múltiples cartas del mismo palo. `faction:cult:10.2.2`
           subchildren:
-            - name: Efectos obligatorios.
-              text: Si un efecto te exige que descartes una carta de zorro, conejo o ratón, debes tratar tus cartas como si fueran del palo que se pide.
-            - name: Imposibilidad de sustición inversa.
-              text: Si un efecto te exige que gastes, descartes, cojas o des una carta de ave específicamente, no es posible sustituir dicha carta por una de otro palo.
-
-        - name: Robar cartas.
-          text: Cuando se te indique que **robes** una carta, coge la carta superior del mazo común. Si no quedan cartas en el mazo, baraja la pila de descartes para formar un nuevo mazo.
-        - name: Gastar y descartar cartas.
-          text: Cuando se te indique que **descartes** o **gastes** una carta, colócala en la pila de descarte, excepto si es una carta de Dominancia (`rule:3.3`). `faction:cult:10.2.6`
-        - name: Revelar cartas.
-          text: Cuando se te indique que **reveles** una carta, colócala en tu **área de juego** (`rule:2.6`). _(Evita que esta se mezcle con otras vinculadas a efectos de tu facción.)_
+            - name: Efectos forzados.
+              text: Cuando se te pida descartar o dar cartas de zorro, conejo o ratón, debes tratar a tus cartas como si fueran del palo que se pide.
+            - name: Sustitución inversa.
+              text: Si se te pide que gastes, descartes, tomes o des una carta de ave, no puedes sustituir esta carta por una de otro palo.
         - name: Cartas de Emboscada.
-          text: "En el mazo hay 5 **cartas de emboscada**: 1 ratón, 1 conejo, 1 zorro y 2 de ave. Puedes gastar estas cartas por su palo, pero no pueden ser fabricadas. Puedes jugar 1 de estas cartas por batalla para infligir impactos (`rule:4.3.1`)."
+          text: Hay cinco **cartas de emboscada**: un ratón, un conejo, un zorro y dos aves. Puedes gastar una carta de emboscada por su palo, pero no puedes fabricarla. También puedes jugar una en batalla para dar golpes (`rule:4.3.1`)."
         - name: Cartas de Dominancia.
-          text: Hay 4 **cartas de dominancia**, una por cada uno de los cuatro palos. Puedes gastar estas cartas de Dominancia por su palo, pero no puedes fabricarlas. En la partida, puedes jugar una de estas cartas para cambiar de forma permanente tu condición de victoria (`rule:3.3`).
+          text: Hay cuatro **cartas de dominancia** que se corresponden con los cuatro palos. Puedes gastar una carta de dominancia por su palo, pero no puedes fabricarla. También puedes jugar una para cambiar de forma permanente tu condición de victoria (`rule:3.3`).
 
     - name: Claros y Caminos
-      pretext: El mapa del bosque está compuestos de una serie de **claros** que conectados por **caminos**.
+      pretext: El mapa del bosque está compuestos de una serie de **claros** conectados por **caminos**.
       children:
         - name: Adyacencia.
-          text: Un claro es adyacente a todos los claros conectados al mismo por 1 camino. `faction:duchy:12.2.2`
-        - name: Palo del claro.
-          text: Cada claro tiene un **palo** asociado _(ratón, conejo o zorro)_. _)Además del icono, el color de los árboles indica el palo del claro.)_
-        - name: Espacios de construcción.
-          text: Cada claro tiene un número de **espacios de construcción** _(casillas blancas)_. Cuando construyas un edificio, debes colocarlo sobre una casilla vacía. No puedes colocar un edificio _(y por tanto, no puedes construir)_ en un claro si no hay casillas vacías.
+          text: Un claro es adyacente a todos aquellos claros que están conectados a él por un camino. `faction:duchy:12.2.2`
+        - name: Palo.
+          text: Cada claro tiene un **palo** _(ratón, conejo o zorro)_.
+        - name: Espacios.
+          text: Cada claro tiene un número de **espacios de construcción** _(recuadros blancos)_. Cuando coloques un edificio, este debe ocupar un espacio vacío. No puedes colocar un edificio en un claro si no hay espacios vacíos.
         - name: Ruinas.
-          text: Las casillas marcadas con una "R" comienzan el juego cubiertas por **ruinas**. Las ruinas solo pueden ser retiradas mediante la acción de Explorar del Vagabundo (`rule:9.5.3`).
+          text: Los espacios marcados con una "R" empiezan el juego ocupados con **ruinas**. Las ruinas no pueden retirarse a menos que se indique expresamente _(como por la acción de Explorar del Vagabundo, `rule:9.5.3`)_.
     
     - name: Ríos
-      pretext: Muchos claros están conectados por **ríos**. Los ríos no son caminos, pero pueden ser tratados como caminos si una norma lo indica explícitamente `faction:riverfolk:11.2.2`. Los ríos no dividen claros ni bosques.
+      pretext: Muchos claros están unidos por **ríos**. _(Los ríos no son caminos, pero pueden traterse como caminos si se indica expresamente. Los ríos no dividen claros ni a los bosques)_ `faction:riverfolk:11.2.2`
       
     - name: Bosques
-      pretext: Las áreas del mapa contenidas entre los caminos y los claros se denominan **bosques**.
+      pretext: Las áreas del mapa delimitadas por caminos impresos y claros se llaman **bosques**.
       children:
         - name: Adyacencia.
-          text: Un bosque es adyacente a todos los claros que toca sin ser atravesado por un camino, y es adyacente a los otros bosques de los que está separado por un solo camino.
-      
-    - name: Piezas
-      pretext: Cada facción posee un conjunto específico de **piezas**, que aparecen detalladas en el reverso de su tablero de facción. Las piezas están limitadas a los componentes que incluye el juego; si se te indica que coloques, tomes o retires una pieza pero no es posible por no haber suficientes, entonces debes colocar, tomar o retirar la máxima cantidad posible.
-      children:
-        - name: Guerreros.
-          text: Si se te indica que coloques un guerrero, cógelo de tu reserva. Si uno de tus guerreros es retirado, devuélvelo a tu reserva. `faction:marquise:6.2.3` `faction:cult:10.2.3` _(El peón del Vagabundo no es un guerrero, y no puede ser retirado.)_
-        - name: Edificios.
-          text: Si se te indica que coloques un edificio, toma el edificio situado más a la izquierda de su correspondiente contador en tu tablero de facción. Si uno de tus edificios es retirado, devuélvelo a la casilla vacía más a la derecha posible de su respectivo contador.
-        - name: Fichas.
-          text: Si se te indica que coloques una ficha, toma la ficha situada más a la izquierda de su correspondiente contador en tu tablero, si lo hay, o cógela de tu reserva. Si una de tus fichas es retirada, devuélvelo a la casilla vacía más a la derecha posible de su respectivo contador, si lo hay, o devuélvela a tu reserva en caso contrario. `faction:marquise:6.2.2` `faction:riverfolk:11.2.5.1`
-        - name: Objetos.
-          text: Si se te indica que tomes un objeto, cógelo de la reserva general del tablero y colócalo en la zona de objetos fabricados de tu tablero de facción. Si se te indica que retires un objeto, descártalo del juego de forma permanente. `faction:vagabond:9.6.4`
-        - name: Otros.
-          text: Si se te indica que utilices cualquier otra pieza específica _(peón, marcador, etc.)_, sigue las instrucciones que se indiquen.
-        
-    - name: Área de juego
-      pretext: Tu **área de juego** es el espacio que hay alrededor de tu tablero de facción, donde debes colocar tu reserva, además de las cartas y/o piezas que indiquen las mecánicas de tu facción. Las cartas de tu área de juego solo pueden ser gastadas, descartadas o utilizadas de acuerdo con lo que estas indiquen o las reglas de tu facción.
-
-    - name: Enemigo
-      pretext: Un **enemigo** es cualquier jugador con el que no formes coalición (`rule:9.2.8`).
+          text: Un bosque es adyacente a todos los claros que lo tocan sin cruzar un camino impreso, y es adyacente a todos los bosques de los que está separado por un único camino impreso.
 
     - name: Gobernador
-      pretext: El **gobernador** de un claro es la persona con la suma total más alta de guerreros y edificios en dicho claro _(las fichas y peones no computan a efectos de gobernar)_. En caso de empate entre varias personas, nadie es considerado gobernador. `faction:eyrie:7.2.2` `faction:vagabond:9.2.2` `faction:cult:10.2.4`   (_Gobernar es imporante ya que afecta directamente a la capacidad de mover y construir de varias facciones_)
+      pretext: Un jugador **gobierna** un claro si es el jugador con el mayor número total de edificios y guerreros en ese claro _(las fichas y peones no contribuyen para el gobierno)_. Si hay un empate entre varios jugadores en un claro, nadie lo gobierna. `faction:eyrie:7.2.2` `faction:vagabond:9.2.2` `faction:cult:10.2.4`
 
 - name: Victoria
   color: "#000000"

--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -1,5 +1,4 @@
-# https://blog.pixelfreestudio.com/how-to-use-forks-in-github-for-collaborative-development/
-# https://github.com/icorreafalconi/root
+
 - name: Reglas de Oro
   color: "#000000"
   pretext: Este capítulo muestra respuestas a preguntas técnicas y concretas. No es necesario que lo leas la primera cez que aprendes el juego.

--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -1091,6 +1091,64 @@
 - name: Variantes y Vagabundos extra
   color: "#000000"
   children:
+    - name: Advanced Setup
+      children:
+        - name: "Paso 1: Escoger y Preparar un Mapa"
+          text: Como grupo, escoged un mapa. Si escogéis un mapa alternativo (`rule:16.2`), seguid su sección de modificaciones a la preparación, después reunid los 12 marcadores de palo, giradlos bocabajo, mezcladlos, y colocar uno en cada claro de modo que cubran el símbolo de palo impreso, si lo hay. Preparad las ruinas (`rule:5.1.4`), la reserva de objetos (`rule:5.1.5`), y los dados (`rule:5.1.6`) de forma habitual.
+        - name: "Paso 2: Escoger un Mazo"
+          text: Como grupo, podéis escoger reemplazar todo el mazo estándar por el mazo de Exiliados y Partisanos.
+        - name: "Paso 3: Preparar Bots"
+          text: Como grupo, podéis escoger jugar con bots, tal y como se describe en la Ley de la Rootbótica.
+        - name: "Paso 4: Sentar a los Jugadores"
+          text: Determinad aleatoriamente el orden de asiento y el primer jugador, el orden de turno va hacia su izquierda.
+        - name: "Paso 5: Preparar los Lugares Míticos"
+          text: Como grupo, podéis escoger usar lugares míticos (`rule:16.5`). Si lo hacéis, podéis ignorar la colocación de las piezas de la Torre o el TRansbordador indicadas en los Mapas Alternativos (`rule:16.2`).
+          subchildren:
+            - name: "Paso 1: Elegir."
+              text: Como grupo, elegid si usáis uno o dos lugares míticos, y devolved  a la caja cualesquiera cartas de lugres míticos que no queráis usar en la partida.
+            - name: "Paso 2: Repartir y Reunir."
+              text: Barajad las cartas de lugares míticos seleccionadas, robas el número elegido _(uno o dos)_ y reunid las piezas de los lugares míticos mostradas en cada carta robada.
+            - name: "Paso 3: Preparar."
+              text: El último jugador según el orden de turno prepara un lugar mítico tal y como se indica en su carta. Si elegisteis jugar con dos lugares míticos, el penúltimo jugador en orden de turno prepara el otro lugar mítico como indica su carta.
+        - name: "Paso 6: Preparar Secuaces"
+          text: Como grupo, podéis escoger jugar con exactamente tres secuaces (`rule:16.4`), como se indica a continuación.
+          subchildren:
+            - name: "Paso 1: Reunir las piezas."
+              text: Barajad las cartas de secuaces. Robad tres cartas de secuaces y devolved el resto a la caja. Reunid las piezas de los secuaces robados formando una reserva.
+            - name: "Paso 2: Degradar."
+              text: Su es una partida a tres jugadores, voltead a uno de los secuaces al azar a su cara de Degradado _(marcada con una "D")_. Si es una partida a cuatro jugadores, voltead a dos secuaces al azar a sus caras de Degradado. Si la partida es a cinco o más jugadores, voltead a los tres secuaces a su cara de Degradado. 
+            - name: "Paso 3: Preparar los Secuaces,"
+              text: Empezando por el último jugador en orden de turno y yendo en sentido inverso al orden de turno, cada jugador prepara a uno de los secuaces seleccionados siguiendo las instrucciones en su carta de secuaz _(algunos no tienen instrucciones)_.
+            - name: "Paso 4: Colocar Marcadores de Secuaces."
+              text: Colocad los tres marcadores de secuaces con el lado mostrando un "4", "8", y "12" bocarriba tapando las casillas "4", "8", y "12" del contador de puntuación en el mapa.
+            - name: "Paso 5: Devolver a la caja las Facciones coincidentes."
+              text: Una facción no puede seleccionarse para la partida si su respectivo secuaz está en juego _(indicado por el icono y el color en su lateral)_. Devuelve los tableros, piezas y cartas de preparación de dichas facciones a la caja.
+        - name: "Paso 7: Robar Cinco Cartas"
+          text: Si es una partida a dos jugadores, retirad del mazo las cuatro cartas de dominancia y devolvedlas a la caja. Barajad el mazo. Cada jugador roba cinco cartas. _(¡No tres como en la preparación estándar! Seleccionarás y te quedarás con tres cartas en el paso 10)_.
+        - name: "Paso 8: Preparar las Facciones"
+          text: Como grupo, podéis escoger y preparar las facciones como se describe en la Preparación Estándar (`rule:5.1`) o podéis usar las cartas de preparación de facción incluidas en la expansión de Los Merodeadores, como se describe abajo.
+          subchildren:
+            - name: "Paso 1: Repartir Cartas de Preparación"
+              text: Barajad las cartas de preparación de las facciones belicosas _(nombre en rojo con una espada)_ y robad una al centro de la mesa. Barajad el resto de cartas de preparación de facciones belicosas con todas las cartas de preparación de las facciones insurgentes _(nombre en gris sin espada)_ y robad una carta por jugador al centro de la mesa. _(Habrá una carta de preparación de facción más que el número de jugadores)_.
+              subchildren:
+                - name: Dos Jugadores.
+                  text: Si es una partida a dos jugadores, retirad todas las cartas de preparación de facciones insurgentes antes de robar ninguna carta _(Podéis dejarlas si jugáis con Secuaces y os va la aventura)_.
+                - name: Bloquear al último insurgente.
+                  text: Si la última carta de preparación de facción robada es insurgente, giradla horizontalmente para mostrar que está bloqueada. No puede escogerse a menos que, como mínimo, una facción belicosa haya sido escogida.
+                - name: Vagabundo.
+                  text: Cuando se robe una carta de preparación de facción de Vagabundo, robad también una carta de personaje de Vagabundo al azar y situadla a su lado bocarriba. Si un jugador escoge a ese Vagabundo como su facción, debe usar esa carta de personaje.
+            - name: "Paso 2: Escoger Facciones."
+              text: Empezando por el último jugador en orden de turno y yendo en sentido inverso al orden de turno, cada jugador escoge una de las cartas de preparación de facción del centro de la mesa y prepara su facción en ese instante _(antes de que el siguiente jugador escoja)_, tal y como se describe en su carta de preparación de facción.
+              subchildren:
+                - name: Patria.
+                  text: Al preparar su facción, los jugadores podrían tener que elegir uno o más claro com claros patria. Los jugadores no pueden escoger como claros patria claros que sus enemigos ya hayan escogido como sus claros patria o claros donde no puedan colocar las piezas indicadas en su preparación.
+                - name: Patrias Adyacentes.
+                  text: Algunas facciones te indican que escojas claros patria que no sean adyacentes a claros patria enemigos, o que haya dos o más claros entre ellos y claros patria enemigos. Si no puedes cumplir un requisito de "dos o más claros entre ellos", puedes escoger un claro patria que no sea adyacente a un claro patria enemigo. Si no puedes cumplir un requisito de "no adyacente", puedes escoger un claro patria que sea adyacente a un claro patria enemigo. _(Sencillamente, piensa en esto como en "Intenta empezar lo más alejado posible")_.
+        - name: "Paso 9: Colocar Marcadores de Puntuación"
+          text: Cada jugador coloca el marcador de puntuación de su facción en la casilla "0" del contador de puntuación.
+        - name: "Paso 10: Seleccionar las Manos Iniciales"
+          text: Cada jugador escoge tres cartas para mantener en su mano y coloca las otras dos bocabajo en el mazo común. Cuando todos lo hayan hecho, barajad el mazo.
+
     - name: Mapas
       children:
         - name: Mapa de Invierno
@@ -1113,7 +1171,7 @@
               text: Los bosques que tocan el lago son **bosques costeros**. Cada bosque costero es adyacente a sus dos bosques costeros próximos _(separados por un claro costero)_.
 
             - name: La Barcaza.
-              text: Una vez por turno, un jugador que esté realizando un movimiento desde el claro costero donde esté situada la Barcaza puede mover a otro claro costero, moviendo la barcaza consigo. _(Se apican las reglas de movimiento normales)_. Después de realizar este movimiento, dicho jugador roba una carta. La Barcaza no puede ser batallada ni retirada.
+              text: Una vez por turno, un jugador que esté realizando un movimiento desde el claro costero donde esté situada la Barcaza puede mover a otro claro costero, moviendo la barcaza consigo. _(Se aplican las reglas de movimiento normales)_. Después de realizar este movimiento, dicho jugador roba una carta. La Barcaza no puede ser batallada ni retirada.
             
         - name: Mapa de la Montaña.
           subchildren:

--- a/src/assets/i18n/rules/es-ES.yml
+++ b/src/assets/i18n/rules/es-ES.yml
@@ -1,39 +1,50 @@
 
 - name: Reglas de Oro
   color: "#000000"
+  pretext: Este capítulo muestra respuestas a preguntas técnicas y concretas. No es necesario que lo leas la primera cez que aprendes el juego.
   children:
     - name: Conflictos de Reglas
       children: 
         - name: Precedencia.
-          text: Si el texto de una carta entra en conflicto con el texto de las referencias de las reglas, la carta tiene precedencia. Si el texto de la guía "Aprende a jugar" entra en conflicto con el texto de la Ley de Root, el texto la Ley tiene preferencia. Si debes seguir las reglas generales y las de una facción, debes seguir ambas siempre si es posible; si no, las Reglas de Facción tienen preferencia. _(Algunas modifican específicamente las reglas generales)_
-        - name: Uso de **no se puede**.
-          plainName: Uso de No se puede.
-          text: Cualquier regla que diga **No se puede** es absoluta. No puede ser alterada a menos que se especifique explícitamente.
-        - name: Efectos Simultáneos.
-          text: Si dos efectos del juego ocurren simultáneamente, el jugador que está jugando el turno actual elige en qué orden ocurren, a menos que se especifique explícitamente.
-        - name: Uso de **tratar como**.
-          plainName: Uso de tratar Como.
-          text: Si un regla indica que **trates** cualquier cosa *como* si fuese otra, ese elemento asume las propiedades del otro. _(Por ejemplo, si causas Indignación como si fueses otro jugador, el otro jugador debería entregar la carta.)_
+          text: Si el texto de una carta entra en conflicto con la Ley, la carta tiene precedencia. Si el texto del Aprende a Jugar entra en conflicto con la Ley, la Ley tiene preferencia. Si puedes seguir a la vez una regla de facción o secuaces y una regla general, sigue ambas; si no, sigue la regla de facción o secuaces.
+        - name: Uso de **no puedes**.
+          plainName: Uso de No puedes.
+          text: Cualquier regla que diga **No puedes** o **No se puede** es absoluta. No puede ignorarse a menos que se especifique explícitamente.
+        - name: Resoluciones y elecciones poco claras
+          text: Siempre que no esté claro en qué orden se deben resolver dos efectos simultáneos, o qué jugador debe actuar primero, el jugador en turno decide.
 
     - name: Información Pública y Privada.
       children:
-        - name: Cartas en mano.
-          text: Las cartas en mano solo pueden ser reveladas si ello se indica específicamente, aunque la cantidad de cartas en mano es información pública. `faction:riverfolk:11.2.3`
+        - name: Manos.
+          text: Sólo puedes revelar las cartas de tu mano si se pude específicamente, pero el número de cartas en las manos es información pública. `faction:riverfolk:11.2.3`
         - name: Descarte.
           text: La pila de descarte puede mirarse en cualquier momento.
           
     - name: Negociación y Pactos
       children:
         - name: Acuerdos.
-          text: Los jugadores pueden negociar en la partida y hacer pactos y acuerdos, pero estos nunca son vinculantes. _(Los acuerdos son estratégicos. No se puede alterar el estado de los componentes.)_
-        - name: Dar cartas.
-          text: Solo es posible dar (o recibir) cartas a otros jugadores si una regla o efecto lo indica explícitamente.
-    
-    - name: Jugadores y Facciones
-      pretext: "A fin de facilitar la lectura, en la Ley se refiere habitualmente a los jugadores de la partida, no a las Facciones. Sin embargo, los efectos del juego _(como habilidades y efectos permanentes)_ son propiedades de las Facciones, no de los jugadores. En caso de controlar piezas de una facción que no controles, debes seguir las reglas de dicha facción salvo que se indique explícitamente otra regla."
-    
-    - name: Estructura de juego y turno
-      pretext: "El turno de cada jugador se divide en tres fases con un orden fijo: Alba, Día y Noche. Después de completar cada fase, la persona situada a la izquierda _(siguiendo el sentido horario)_ comienza su turno. El juego continúa hasta que un jugador haya ganado(`rule:3.1`)."
+          text: Los jugadores son libres de discutir acuerdos durante la partida, pero los acuerdos entre los jugadores no son vinculantes.
+        - name: Cartas.
+          text: Los jugadores sólo pueden dar cartas a otros si una regla se lo permite.
+    - name: Secuencia de Juego
+      children:
+        - name: Turno.
+          text: Cada turno de un jugador consta de tres fases: Alba, Día y Noche. Cualquier texto que diga "al principio de" una fase, sucede antes de cualquier otra cosa en esa fase, si el texto dice "al final de" sucede después de todo lo demás en esa fase y justo antes del inicio de la siguiente, si la hay. Después de que un jugador finalice su Noche, el siguiente jugador en sentido horario comienza su turno. El juego continúa hasta que un jugador gana la partida (`rule:3.1`).
+        - name: Interrumpir
+          text: No puedes interrumpir una acción _(incluso una múltiple como la Marcha del Marquesado)_, habilidad _(como la Exposición de los Córvidos)_ o efecto persistente _(como la carta Emigrante del Nido)_ con otro efecto a menos que se permita explícitamente. _(Por ejemplo, la carta Pertrechados dice que se usa "En batalla...")_
+    - name: Piezas
+      children:
+        - name: Límites.
+          text: Las piezas están limitadas a las contenidas en el juego. No uses piezas de reemplazo si se agota alguna de ellas.
+        - name: Facción Inicial.
+          text: Cada jugador controla a la facción que elija durante la preparación (5) y las piezas listadas en el dorso de su tablero de facción salvo los objetos. De forma genérica, estas se denominan **piezas de facción**. De forma específica, se denominan **piezas de [nombre de facción]**. _(Por ejemplo, "tus guerreros de facción" y "guerreros de tu facción" y "guuerreros del Marquesado", todos ellos se refieren a los guerreros de madera naranja con forma de gato)_.
+        - name: Pertenencia de las piezas.
+          text: El propietario de las piezas de una facción no puede cambiar. _(Por ejemplo, el Marquesado no puede usar sus hospitales de Campaña con los secuaces o los mercenarios de la Compañía, ya que no son guerreros del Marquesado)_.
+        - name: Manejo de las piezas.
+          text: Las piezas se colocan y retiran como se indica en el Glosario (`rule:16.6.5`, `rule:16.6.28`). Si se te indica que coloques, tomes o retires piezas pero no puedes hacerlo al completo, debes colocar, tomar o retirar las máximas posibles. _(Esto no te permite evitar costes o requisitos. No puedes hacer menos de lo máximo que puedes hacer)_.
+        - name: Uso de **Forzar**.
+          plainName: Uso de Forzar.
+          text: Algunos efectos te permiten **forzar** a un jugador o a sus piezas a actuar. Resuelve la situación del mismo modo en el que ese jugador lo haría _(siguiendo las reglas generales)_, teniendo en cuenta posibles efectos. _(Por ejemplo, si fuerzas al Nido a mover guerreros, se benefician de la regla Señores del Bosque)_.
 
 - name: Términos Clave y Conceptos de juego
   color: "#000000"


### PR DESCRIPTION
I've updated the Spanish Law of Root to what is now the 4th edition (2023), corresponding to the 10th printing in English (which can be seen [here](https://cdn.shopify.com/s/files/1/0106/0162/7706/files/Root_Base_Law_of_Root_June_30_2023.pdf)). Among the many changes, the most substantial are:

1. Rewriting of previous sections, to take into account new wording corresponding to the Marauders expansion.
2. Inclusion of sections The Lord of the Hundreds, the Keepers in Iron, Advanced Setup, hirelings, Landmarks and the Glossary.
    1. Worth noting, I included rules 14.3.1 and 15.3.1 (both Gather Pieces) from the original English version, that are missing in the Spanish version (these two Faction Setups have three steps, not four, in the Spanish version).
3. Inclusion of the [Tenth Print changes](https://docs.google.com/document/d/1yBwLDRo0OuziCeRiX2SOpv63gH8_dmoCrGd8NyDuyC8/edit?tab=t.0), which are available in https://root.seiyria.com, but not in the original Spanish version. The translation is mine.
4. I did not translate rule [16.1.8.II.C Multiple Homeland Adjacency.](https://root.seiyria.com/#16.1.8.2.3-multiple-homeland-adjacency) because it is not written neither in the Spanish Law nor in the link of the English Law above.
5. A final detail: in the Law the card Boat Builders is mentioned in rule **E.3.5 Separate Effects**. In the Spanish Law this name was translated to «Constructores de Botes», which is the correct translation of "Boat Builders", but does not match the name printed in the card itself in the E&P deck, which is «Carpinteros de Ribera» (lit. Riverside Shipwrights). I've decided to keep the name of the card, not the Law, for consistency.